### PR TITLE
Fixes build flag. Implements basic ParseNotation API method.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,3 +38,14 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 	}
 	return mapGameToOutputGame(parsedGame.doAction(parsedAction)), mapInternalActionToAction(parsedAction), nil
 }
+
+func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, []OutputGameStep, error) {
+	parsedGame, err := a.parseGame(game)
+	if err != nil {
+		return OutputGame{}, []OutputGameStep{}, err
+	}
+
+	// TODO at the moment there only exists an algebraic notation parser
+	gameSteps, err := newNotationParserAlgebraic(characteristics{}).parse(parsedGame, notationString)
+	return mapGameToOutputGame(parsedGame), mapGameStepsToOutputGameSteps(gameSteps), err
+}

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -69,6 +69,12 @@ type OutputAction struct {
 	CapturedPieceType  string `json:"capturedPieceType"`
 }
 
+type OutputGameStep struct {
+	Game         OutputGame   `json:"game"`
+	Action       OutputAction `json:"action"`
+	ActionString string       `json:"actionString"`
+}
+
 func mapGameToOutputGame(g game) OutputGame {
 	var o OutputGame
 
@@ -166,4 +172,16 @@ func mapInternalActionToAction(a action) OutputAction {
 		PromotionPieceType: a.promotionPieceType.String(),
 		CapturedPieceType:  a.capturedPiece.pieceType.String(),
 	}
+}
+
+func mapGameStepsToOutputGameSteps(gss []gameStep) []OutputGameStep {
+	ogs := make([]OutputGameStep, len(gss))
+	for _, gs := range gss {
+		ogs = append(ogs, OutputGameStep{
+			Game:         mapGameToOutputGame(gs.g),
+			Action:       mapInternalActionToAction(gs.a),
+			ActionString: gs.s,
+		})
+	}
+	return ogs
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//+build !js,wasm
+// +build !js
 
 package main
 
@@ -9,13 +9,12 @@ import (
 )
 
 var (
-	flagServe       = flag.Int("serve", 0, "Start a server on the specified port.")
-	flagDefaultGame = flag.Bool("defaultGame", false, "Default API call. Returns a default game.")
-	flagParseGame   = flag.String("parseGame", "", "ParseGame API call. Requires a JSON string with arguments. Please review spec.")
-	flagDoAction    = flag.String("doAction", "", "DoAction API call. Requires a JSON string with arguments. Please review spec.")
+	flagServe         = flag.Int("serve", 0, "Start a server on the specified port.")
+	flagDefaultGame   = flag.Bool("defaultGame", false, "Default API call. Returns a default game.")
+	flagParseGame     = flag.String("parseGame", "", "ParseGame API call. Requires a JSON string with arguments. Please review spec.")
+	flagDoAction      = flag.String("doAction", "", "DoAction API call. Requires a JSON string with arguments. Please review spec.")
+	flagParseNotation = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
 )
-
-// api.InputGame{FENString: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"},
 
 func main() {
 	flag.Parse()
@@ -23,6 +22,7 @@ func main() {
 	http.HandleFunc("/parseGame", handleServerParseGame)
 	http.HandleFunc("/defaultGame", handleServerDefaultGame)
 	http.HandleFunc("/doAction", handleServerDoAction)
+	http.HandleFunc("/parseNotation", handleServerParseNotation)
 
 	switch {
 	case *flagServe != 0:
@@ -33,5 +33,7 @@ func main() {
 		handleCliParseGame(flagParseGame)
 	case *flagDoAction != "":
 		handleCliDoAction(flagDoAction)
+	case *flagParseNotation != "":
+		handleCliParseNotation(flagParseNotation)
 	}
 }


### PR DESCRIPTION
This PR implements the ParseNotation API call.

It is a work in progress, because it only supports Algebraic Notation at the moment, but it is well tested (the notation parser is).

I want to merge this early so that it can be used for automatically proof-reading the pre-prints of the publication of "Practical Chess Endings: Now in Algebraic!".