### PR TITLE
Implements ICCF notation parsing, printing.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -74,7 +74,7 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 //
 // `1. e4 e5\n2. Bc4 Nc6\n3. Qh5 Nf6??\n4. Qxf7#`
 //
-// At the moment, only Algebraic Notation is supported, but support for most
+// At the moment, only Algebraic and ICCF Notations are supported, but support for most
 // notations is planned at a later release.
 //
 // Please refer to InputGame's, OutputGame's and OutputGameStep's docs for format
@@ -85,9 +85,10 @@ func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, [
 		return OutputGame{}, []OutputGameStep{}, err
 	}
 
-	// TODO at the moment there only exists algebraic parser
+	// TODO at the moment there only exists algebraic and iccf parsers
 	notationParsers := []*parser.NotationParser{
 		parser.NewNotationParserAlgebraic(parser.Characteristics{}),
+		parser.NewNotationParserICCF(parser.Characteristics{}),
 	}
 
 	var gameSteps []core.GameStep

--- a/core/entities.go
+++ b/core/entities.go
@@ -176,6 +176,20 @@ func (t PieceType) String() string {
 	return ""
 }
 
+func (t PieceType) ToICCF() string {
+	switch t {
+	case PieceQueen:
+		return "1"
+	case PieceRook:
+		return "2"
+	case PieceBishop:
+		return "3"
+	case PieceKnight:
+		return "4"
+	}
+	return ""
+}
+
 func (t PieceType) ToSmith() string {
 	switch t {
 	case PieceQueen:
@@ -278,6 +292,10 @@ func (c XY) eq(c2 XY) bool {
 
 func (c XY) ToAlgebraic() string {
 	return fmt.Sprintf("%v%v", string("abcdefgh"[c.X]), 8-c.Y)
+}
+
+func (c XY) ToICCF() string {
+	return fmt.Sprintf("%v%v", c.X+1, 8-c.Y)
 }
 
 func (c XY) ToDescriptive(turn color) string {

--- a/parser/notation_iccf.go
+++ b/parser/notation_iccf.go
@@ -1,0 +1,113 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/marianogappa/cheesse/core"
+)
+
+func NewNotationParserICCF(initialCharacteristics Characteristics) *NotationParser {
+	var (
+		evolveCharacteristics = func(ch Characteristics, sc Characteristics) (Characteristics, error) {
+			// ICCF notation doesn't have complex characteristics evolution
+			// Just merge the characteristics
+			if sc.usesNewlineAsFullMoveSeparator != nil {
+				if ch.usesNewlineAsFullMoveSeparator == nil {
+					ch.usesNewlineAsFullMoveSeparator = sc.usesNewlineAsFullMoveSeparator
+				} else if *ch.usesNewlineAsFullMoveSeparator != *sc.usesNewlineAsFullMoveSeparator {
+					return ch, fmt.Errorf("expecting newline as full move separator %v but found %v", *ch.usesNewlineAsFullMoveSeparator, *sc.usesNewlineAsFullMoveSeparator)
+				}
+			}
+			return ch, nil
+		}
+		transitions = map[string]map[string]func([]string, core.Game) []tokenMatch{
+			"full_move_start": {
+				`[\t\f\r ]*([0-9]+)?(\.)?[\t\f\r ]*`: func(ms []string, g core.Game) []tokenMatch {
+					return []tokenMatch{{ms[0], nil, Characteristics{}}}
+				},
+			},
+			"half_move_separator": {
+				`[\t\f\r ]+`: func(ms []string, g core.Game) []tokenMatch {
+					return []tokenMatch{{ms[0], nil, Characteristics{}}}
+				},
+			},
+			"full_move_separator": {
+				`([\t\f\r ]*?\n|[\t\f\r ]+)`: func(ms []string, g core.Game) []tokenMatch {
+					var usesNewlineAsFullMoveSeparator *bool
+					if strings.Contains(ms[0], "\n") {
+						usesNewlineAsFullMoveSeparator = pBool(true)
+					}
+					return []tokenMatch{{ms[0], nil, Characteristics{usesNewlineAsFullMoveSeparator: usesNewlineAsFullMoveSeparator}}}
+				},
+			},
+			"move": {
+				`([1-8])([1-8])([1-8])([1-8])([1-8])?`: func(ms []string, g core.Game) []tokenMatch {
+					fromFile, fromRank, toFile, toRank, promotionPieceType := ms[1], ms[2], ms[3], ms[4], ms[5]
+
+					ap := actionPattern{
+						fromPieceType:      core.PieceNone, // ICCF doesn't specify piece type, let parser infer it
+						fromX:              iccfFileToPInt(fromFile),
+						fromY:              iccfRankToPInt(fromRank),
+						toX:                iccfFileToPInt(toFile),
+						toY:                iccfRankToPInt(toRank),
+						isCapture:          nil, // ??
+						isPromotion:        pBool(promotionPieceType != ""),
+						isCastle:           nil,
+						isResign:           nil,
+						isEnPassantCapture: nil,
+						isCheck:            nil,
+						isCheckmate:        nil,
+						promotionPieceType: iccfStringToPieceType(promotionPieceType),
+					}
+
+					return []tokenMatch{{ms[0], &ap, Characteristics{}}}
+				},
+			},
+		}
+	)
+	return newNotationParser(transitions, evolveCharacteristics, initialCharacteristics)
+}
+
+func iccfFileToPInt(file string) *int {
+	if file == "" {
+		return nil
+	}
+	iccfFile, err := strconv.Atoi(file)
+	if err != nil {
+		return nil
+	}
+	if iccfFile < 1 || iccfFile > 8 {
+		return nil
+	}
+	x := iccfFile - 1
+	return &x
+}
+
+func iccfRankToPInt(rank string) *int {
+	if rank == "" {
+		return nil
+	}
+	iccfRank, err := strconv.Atoi(rank)
+	if err != nil {
+		return nil
+	}
+	if iccfRank < 1 || iccfRank > 8 {
+		return nil
+	}
+	y := 8 - iccfRank
+	return &y
+}
+
+func iccfStringToPieceType(s string) core.PieceType {
+	if pt, ok := map[string]core.PieceType{
+		"1": core.PieceQueen,
+		"2": core.PieceRook,
+		"3": core.PieceBishop,
+		"4": core.PieceKnight,
+	}[s]; ok {
+		return pt
+	}
+	return core.PieceNone
+}

--- a/parser/notation_iccf_test.go
+++ b/parser/notation_iccf_test.go
@@ -1,0 +1,171 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/marianogappa/cheesse/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotationParserICCF(t *testing.T) {
+	testCases := []struct {
+		fen                   string
+		s                     string
+		expectedErr           error
+		expectedMatchedTokens []string
+		expectedAlgebraic     []string
+		expectedFEN           string
+	}{
+		{
+			fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			s: `1. 5254 5755
+2. 7163 2836
+3. 6125 1716
+4. 2514 7866
+5. 5171 6857
+6. 6151 2725
+7. 1423 4746
+8. 3233 5878`,
+			expectedErr: nil,
+			expectedMatchedTokens: []string{
+				"5254",
+				"5755",
+				"7163",
+				"2836",
+				"6125",
+				"1716",
+				"2514",
+				"7866",
+				"5171",
+				"6857",
+				"6151",
+				"2725",
+				"1423",
+				"4746",
+				"3233",
+				"5878",
+			},
+			expectedAlgebraic: []string{
+				"1. e4 e5",
+				"2. Nf3 Nc6",
+				"3. Bb5 a6",
+				"4. Ba4 Nf6",
+				"5. 0-0 Be7",
+				"6. Re1 b5",
+				"7. Bb3 d6",
+				"8. c3 0-0",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test notation parser ICCF %v", i), func(t *testing.T) {
+			g, err := core.NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+			gameSteps, err := NewNotationParserICCF(Characteristics{}).Parse(g, tc.s)
+			require.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != nil {
+				return
+			}
+			if tc.expectedMatchedTokens != nil {
+				require.Len(t, tc.expectedMatchedTokens, len(gameSteps))
+				for i, gameStep := range gameSteps {
+					assert.Equal(t, tc.expectedMatchedTokens[i], gameStep.StepString)
+				}
+			}
+			actualPrinted, err := printer.AlgebraicPrinter{}.PrintGame(gameSteps, printer.GameCharacteristics{})
+			require.Nil(t, err)
+			if tc.expectedAlgebraic != nil {
+				assert.Equal(t, tc.expectedAlgebraic, actualPrinted)
+			}
+			if tc.expectedFEN != "" {
+				assert.Equal(t, tc.expectedFEN, gameSteps[len(gameSteps)-1].StepGame.ToFEN())
+			}
+		})
+	}
+}
+
+func TestNotationParserICCFRoundTrip(t *testing.T) {
+	// Test round-trip: ICCF → Algebraic → ICCF
+	originalICCF := `1. 5254 5755
+2. 7163 2836
+3. 6125 1716
+4. 2514 7866
+5. 5171 6857
+6. 6151 2725
+7. 1423 4746
+8. 3233 5878`
+
+	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+	t.Run("ICCF to Algebraic to ICCF round-trip", func(t *testing.T) {
+		// Step 1: Parse ICCF notation
+		g, err := core.NewGameFromFEN(fen)
+		require.NoError(t, err)
+
+		gameSteps, err := NewNotationParserICCF(Characteristics{}).Parse(g, originalICCF)
+		require.NoError(t, err)
+
+		// Step 2: Convert to Algebraic notation
+		algebraicPrinted, err := printer.AlgebraicPrinter{}.PrintGame(gameSteps, printer.GameCharacteristics{})
+		require.NoError(t, err)
+
+		// Step 3: Parse Algebraic notation back to game steps
+		algebraicString := ""
+		for _, move := range algebraicPrinted {
+			algebraicString += move + "\n"
+		}
+
+		gameStepsFromAlgebraic, err := NewNotationParserAlgebraic(Characteristics{}).Parse(g, algebraicString)
+		require.NoError(t, err)
+
+		// Step 4: Convert back to ICCF notation
+		iccfPrinted, err := printer.ICCFPrinter{}.PrintGame(gameStepsFromAlgebraic, printer.GameCharacteristics{})
+		require.NoError(t, err)
+
+		// Step 5: Parse the ICCF notation again
+		iccfString := ""
+		for _, move := range iccfPrinted {
+			iccfString += move + "\n"
+		}
+
+		finalGameSteps, err := NewNotationParserICCF(Characteristics{}).Parse(g, iccfString)
+		require.NoError(t, err)
+
+		// Verify that the final ICCF moves match the original ICCF moves
+		require.Len(t, finalGameSteps, len(gameSteps))
+
+		for i, originalStep := range gameSteps {
+			finalStep := finalGameSteps[i]
+			assert.Equal(t, originalStep.StepAction.FromPiece.XY, finalStep.StepAction.FromPiece.XY,
+				"Move %d: From position should match", i+1)
+			assert.Equal(t, originalStep.StepAction.ToXY, finalStep.StepAction.ToXY,
+				"Move %d: To position should match", i+1)
+			assert.Equal(t, originalStep.StepAction.FromPiece.PieceType, finalStep.StepAction.FromPiece.PieceType,
+				"Move %d: Piece type should match", i+1)
+			if originalStep.StepAction.IsPromotion {
+				assert.Equal(t, originalStep.StepAction.PromotionPieceType, finalStep.StepAction.PromotionPieceType,
+					"Move %d: Promotion piece type should match", i+1)
+			}
+		}
+
+		// Also verify that the string representations match exactly
+		assert.Equal(t, iccfPrinted, []string{
+			"1. 5254 5755",
+			"2. 7163 2836",
+			"3. 6125 1716",
+			"4. 2514 7866",
+			"5. 5171 6857",
+			"6. 6151 2725",
+			"7. 1423 4746",
+			"8. 3233 5878",
+		}, "Final ICCF string representation should match original")
+
+		t.Logf("Original ICCF: %s", originalICCF)
+		t.Logf("Algebraic: %v", algebraicPrinted)
+		t.Logf("Final ICCF: %v", iccfPrinted)
+	})
+}

--- a/printer/iccf.go
+++ b/printer/iccf.go
@@ -1,0 +1,26 @@
+package printer
+
+import (
+	"fmt"
+
+	"github.com/marianogappa/cheesse/core"
+)
+
+type ICCFPrinter struct{}
+
+func (p ICCFPrinter) PrintGame(gameSteps []core.GameStep, gameCharacteristics GameCharacteristics) ([]string, error) {
+	return genericGamePrinter(gameSteps, gameCharacteristics, p)
+}
+
+func (p ICCFPrinter) PrintAction(gameStep core.GameStep, gameCharacteristics GameCharacteristics) (string, error) {
+	promotion := ""
+	if gameStep.StepAction.IsPromotion {
+		promotion = gameStep.StepAction.PromotionPieceType.ToICCF()
+	}
+	return fmt.Sprintf(
+		"%v%v%v",
+		gameStep.StepAction.FromPiece.XY.ToICCF(),
+		gameStep.StepAction.ToXY.ToICCF(),
+		promotion,
+	), nil
+}

--- a/printer/iccf_test.go
+++ b/printer/iccf_test.go
@@ -1,0 +1,387 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/marianogappa/cheesse/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestICCFPrinter_PrintAction(t *testing.T) {
+	testCases := []struct {
+		name                string
+		gameStep            core.GameStep
+		gameCharacteristics GameCharacteristics
+		expectedResult      string
+	}{
+		{
+			name: "Pawn move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 6}},
+					ToXY:      core.XY{X: 4, Y: 4},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 6}},
+					ToXY:      core.XY{X: 4, Y: 4},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "5254",
+		},
+		{
+			name: "Knight move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKnight, Owner: core.ColorWhite, XY: core.XY{X: 6, Y: 7}},
+					ToXY:      core.XY{X: 5, Y: 5},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKnight, Owner: core.ColorWhite, XY: core.XY{X: 6, Y: 7}},
+					ToXY:      core.XY{X: 5, Y: 5},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "7163",
+		},
+		{
+			name: "Bishop move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceBishop, Owner: core.ColorWhite, XY: core.XY{X: 5, Y: 7}},
+					ToXY:      core.XY{X: 0, Y: 2},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceBishop, Owner: core.ColorWhite, XY: core.XY{X: 5, Y: 7}},
+					ToXY:      core.XY{X: 0, Y: 2},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "6116",
+		},
+		{
+			name: "Rook move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceRook, Owner: core.ColorWhite, XY: core.XY{X: 0, Y: 7}},
+					ToXY:      core.XY{X: 0, Y: 5},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceRook, Owner: core.ColorWhite, XY: core.XY{X: 0, Y: 7}},
+					ToXY:      core.XY{X: 0, Y: 5},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "1113",
+		},
+		{
+			name: "Queen move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceQueen, Owner: core.ColorWhite, XY: core.XY{X: 3, Y: 7}},
+					ToXY:      core.XY{X: 7, Y: 3},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceQueen, Owner: core.ColorWhite, XY: core.XY{X: 3, Y: 7}},
+					ToXY:      core.XY{X: 7, Y: 3},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "4185",
+		},
+		{
+			name: "King move",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 6, Y: 7},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 6, Y: 7},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "5171",
+		},
+		{
+			name: "Pawn promotion to Queen",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceQueen,
+				}),
+				StepAction: core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceQueen,
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "57581",
+		},
+		{
+			name: "Pawn promotion to Rook",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceRook,
+				}),
+				StepAction: core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceRook,
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "57582",
+		},
+		{
+			name: "Pawn promotion to Bishop",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceBishop,
+				}),
+				StepAction: core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceBishop,
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "57583",
+		},
+		{
+			name: "Pawn promotion to Knight",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceKnight,
+				}),
+				StepAction: core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 1}},
+					ToXY:               core.XY{X: 4, Y: 0},
+					IsPromotion:        true,
+					PromotionPieceType: core.PieceKnight,
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "57584",
+		},
+	}
+
+	printer := ICCFPrinter{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := printer.PrintAction(tc.gameStep, tc.gameCharacteristics)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestICCFPrinter_PrintGame(t *testing.T) {
+	testCases := []struct {
+		name                string
+		fen                 string
+		gameICCF            string
+		gameCharacteristics GameCharacteristics
+		expectedResult      []string
+	}{
+		{
+			name: "Basic opening sequence",
+			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			gameICCF: `1. 5254 5755
+2. 7163 2836
+3. 6125 1716
+4. 2514 7866
+5. 5171 6857
+6. 6151 2725
+7. 1423 4746
+8. 3233 5878`,
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult: []string{
+				"1. 5254 5755",
+				"2. 7163 2836",
+				"3. 6125 1716",
+				"4. 2514 7866",
+				"5. 5171 6857",
+				"6. 6151 2725",
+				"7. 1423 4746",
+				"8. 3233 5878",
+			},
+		},
+		{
+			name: "Simple two-move sequence",
+			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			gameICCF: `1. 5254 5755
+2. 7163 2836`,
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult: []string{
+				"1. 5254 5755",
+				"2. 7163 2836",
+			},
+		},
+	}
+
+	printer := ICCFPrinter{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := core.NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+			gameSteps, err := parser.NewNotationParserICCF(parser.Characteristics{}).Parse(g, tc.gameICCF)
+			require.NoError(t, err)
+			result, err := printer.PrintGame(gameSteps, tc.gameCharacteristics)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestICCFPrinter_RoundTrip(t *testing.T) {
+	// Test round-trip: ICCF → Game Steps → ICCF
+	originalICCF := `1. 5254 5755
+2. 7163 2836
+3. 6125 1716
+4. 2514 7866
+5. 5171 6857
+6. 6151 2725
+7. 1423 4746
+8. 3233 5878`
+
+	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+	t.Run("ICCF round-trip consistency", func(t *testing.T) {
+		// Step 1: Parse ICCF notation
+		g, err := core.NewGameFromFEN(fen)
+		require.NoError(t, err)
+
+		gameSteps, err := parser.NewNotationParserICCF(parser.Characteristics{}).Parse(g, originalICCF)
+		require.NoError(t, err)
+
+		// Step 2: Print back to ICCF notation
+		iccfPrinted, err := ICCFPrinter{}.PrintGame(gameSteps, GameCharacteristics{})
+		require.NoError(t, err)
+
+		// Step 3: Parse the printed ICCF notation again
+		iccfString := ""
+		for _, move := range iccfPrinted {
+			iccfString += move + "\n"
+		}
+
+		finalGameSteps, err := parser.NewNotationParserICCF(parser.Characteristics{}).Parse(g, iccfString)
+		require.NoError(t, err)
+
+		// Verify that the final game steps match the original game steps
+		require.Len(t, finalGameSteps, len(gameSteps))
+
+		for i, originalStep := range gameSteps {
+			finalStep := finalGameSteps[i]
+			assert.Equal(t, originalStep.StepAction.FromPiece.XY, finalStep.StepAction.FromPiece.XY,
+				"Move %d: From position should match", i+1)
+			assert.Equal(t, originalStep.StepAction.ToXY, finalStep.StepAction.ToXY,
+				"Move %d: To position should match", i+1)
+			assert.Equal(t, originalStep.StepAction.FromPiece.PieceType, finalStep.StepAction.FromPiece.PieceType,
+				"Move %d: Piece type should match", i+1)
+			if originalStep.StepAction.IsPromotion {
+				assert.Equal(t, originalStep.StepAction.PromotionPieceType, finalStep.StepAction.PromotionPieceType,
+					"Move %d: Promotion piece type should match", i+1)
+			}
+		}
+
+		// Also verify that the string representations match exactly
+		assert.Equal(t, iccfPrinted, []string{
+			"1. 5254 5755",
+			"2. 7163 2836",
+			"3. 6125 1716",
+			"4. 2514 7866",
+			"5. 5171 6857",
+			"6. 6151 2725",
+			"7. 1423 4746",
+			"8. 3233 5878",
+		}, "Final ICCF string representation should match original")
+
+		t.Logf("Original ICCF: %s", originalICCF)
+		t.Logf("Final ICCF: %v", iccfPrinted)
+	})
+}
+
+func TestICCFPrinter_EdgeCases(t *testing.T) {
+	testCases := []struct {
+		name           string
+		gameStep       core.GameStep
+		expectedResult string
+	}{
+		{
+			name: "Castling kingside",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 6, Y: 7},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 6, Y: 7},
+				},
+			},
+			expectedResult: "5171",
+		},
+		{
+			name: "Castling queenside",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 2, Y: 7},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PieceKing, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 7}},
+					ToXY:      core.XY{X: 2, Y: 7},
+				},
+			},
+			expectedResult: "5131",
+		},
+		{
+			name: "En passant capture",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame().DoAction(core.Action{
+					FromPiece: core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 3}},
+					ToXY:      core.XY{X: 5, Y: 2},
+				}),
+				StepAction: core.Action{
+					FromPiece: core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 4, Y: 3}},
+					ToXY:      core.XY{X: 5, Y: 2},
+				},
+			},
+			expectedResult: "5566",
+		},
+	}
+
+	printer := ICCFPrinter{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := printer.PrintAction(tc.gameStep, GameCharacteristics{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/marianogappa/cheesse/issues/7

Implements support for ICCF notation by adding a parser and a printer. Also adds it to the list of supported notation converters.