### PR TITLE
Remove incorrect IsEnPassant action state

### DIFF
--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -143,7 +143,6 @@ type OutputAction struct {
 	IsCapture          bool   `json:"isCapture"`
 	IsResign           bool   `json:"isResign"`
 	IsPromotion        bool   `json:"isPromotion"`
-	IsEnPassant        bool   `json:"isEnPassant"`
 	IsEnPassantCapture bool   `json:"isEnPassantCapture"`
 	IsCastle           bool   `json:"isCastle"`
 	IsKingsideCastle   bool   `json:"isKingsideCastle"`
@@ -264,7 +263,6 @@ func mapInternalActionToAction(a core.Action) OutputAction {
 		IsCapture:          a.IsCapture,
 		IsResign:           a.IsResign,
 		IsPromotion:        a.IsPromotion,
-		IsEnPassant:        a.IsEnPassant,
 		IsEnPassantCapture: a.IsEnPassantCapture,
 		IsCastle:           a.IsCastle,
 		IsKingsideCastle:   a.IsKingsideCastle,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -251,7 +251,6 @@ func TestDoAction(t *testing.T) {
 				FromPieceType:   "Pawn",
 				FromPieceSquare: "e2",
 				ToSquare:        "e4",
-				IsEnPassant:     true,
 			},
 		},
 		{
@@ -273,7 +272,6 @@ func TestDoAction(t *testing.T) {
 				FromPieceType:   "Pawn",
 				FromPieceSquare: "e2",
 				ToSquare:        "e4",
-				IsEnPassant:     true,
 			},
 		},
 		{

--- a/core/chess.go
+++ b/core/chess.go
@@ -190,11 +190,6 @@ func (p Piece) buildAction(toXY XY, g Game, promotionPieceType PieceType) (Actio
 		}
 	}
 
-	// Set the isEnPassant flag
-	if p.PieceType == PiecePawn && ((p.Owner == ColorBlack && p.XY.Y == 1 && toXY.Y == 3) || (p.Owner == ColorWhite && p.XY.Y == 6 && toXY.Y == 4)) {
-		a.IsEnPassant = true
-	}
-
 	// Castling context
 	if p.PieceType == PieceKing && abs(toXY.X-p.XY.X) > 1 { // It's a castle attempt
 		// Set castle type context
@@ -329,11 +324,12 @@ func (g Game) DoAction(a Action) Game {
 	if lastTurn == ColorBlack {
 		newGame.FullMoveNumber = g.FullMoveNumber + 1
 	}
-	newGame.IsLastMoveEnPassant = a.IsEnPassant
-	if a.IsEnPassant && lastTurn == ColorBlack {
+	isDoubleAdvance := a.FromPiece.PieceType == PiecePawn && abs(a.ToXY.Y-a.FromPiece.XY.Y) == 2
+	newGame.IsLastMoveEnPassant = isDoubleAdvance
+	if isDoubleAdvance && lastTurn == ColorBlack {
 		newGame.EnPassantTargetSquare = XY{X: a.ToXY.X, Y: a.ToXY.Y - 1}
 	}
-	if a.IsEnPassant && lastTurn == ColorWhite {
+	if isDoubleAdvance && lastTurn == ColorWhite {
 		newGame.EnPassantTargetSquare = XY{X: a.ToXY.X, Y: a.ToXY.Y + 1}
 	}
 

--- a/core/entities.go
+++ b/core/entities.go
@@ -93,7 +93,6 @@ type Action struct {
 	IsCapture          bool
 	IsResign           bool
 	IsPromotion        bool
-	IsEnPassant        bool
 	IsEnPassantCapture bool
 	IsCastle           bool
 	IsKingsideCastle   bool
@@ -118,8 +117,6 @@ func (a Action) String() string {
 		return fmt.Sprintf("%s resigns", a.FromPiece.Owner)
 	case a.IsPromotion:
 		return fmt.Sprintf("%s's Pawn at %v promotes to %v", a.FromPiece.Owner, a.FromPiece.XY.ToAlgebraic(), a.PromotionPieceType)
-	case a.IsEnPassant:
-		return fmt.Sprintf("%s's Pawn at %v does en passant", a.FromPiece.Owner, a.FromPiece.XY.ToAlgebraic())
 	case a.IsKingsideCastle:
 		return fmt.Sprintf("%s kingside castles", a.FromPiece.Owner)
 	case a.IsQueensideCastle:
@@ -129,7 +126,7 @@ func (a Action) String() string {
 }
 
 func (a Action) DebugString() string {
-	return fmt.Sprintf("%v at (%v, %v) to (%v, %v), isCapture: %v , isResign: %v , isPromotion: %v , isEnPassant: %v , isEnPassantCapture: %v , isCastle: %v , isKingsideCastle: %v , isQueensideCastle: %v, promotionPieceType: %v, capturedPiece: %v at (%v, %v)",
+	return fmt.Sprintf("%v at (%v, %v) to (%v, %v), isCapture: %v , isResign: %v , isPromotion: %v , isEnPassantCapture: %v , isCastle: %v , isKingsideCastle: %v , isQueensideCastle: %v, promotionPieceType: %v, capturedPiece: %v at (%v, %v)",
 		a.FromPiece.PieceType,
 		a.FromPiece.XY.X,
 		a.FromPiece.XY.Y,
@@ -138,7 +135,6 @@ func (a Action) DebugString() string {
 		a.IsCapture,
 		a.IsResign,
 		a.IsPromotion,
-		a.IsEnPassant,
 		a.IsEnPassantCapture,
 		a.IsCastle,
 		a.IsKingsideCastle,

--- a/core/entities_test.go
+++ b/core/entities_test.go
@@ -61,14 +61,6 @@ func TestActionString(t *testing.T) {
 		},
 		{
 			a: Action{
-				FromPiece:   Piece{PieceType: PiecePawn, Owner: ColorBlack, XY: XY{5, 1}},
-				ToXY:        XY{5, 3},
-				IsEnPassant: true,
-			},
-			s: "Black's Pawn at f7 does en passant",
-		},
-		{
-			a: Action{
 				FromPiece:          Piece{PieceType: PiecePawn, Owner: ColorBlack, XY: XY{3, 5}},
 				ToXY:               XY{4, 6},
 				IsCapture:          true,

--- a/core/pawn_actions_test.go
+++ b/core/pawn_actions_test.go
@@ -72,7 +72,7 @@ func TestPawnActions(t *testing.T) {
 			xy:    XY{0, 1},
 			actions: []Action{
 				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorBlack, XY: XY{0, 1}}, ToXY: XY{0, 2}},
-				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorBlack, XY: XY{0, 1}}, ToXY: XY{0, 3}, IsEnPassant: true},
+				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorBlack, XY: XY{0, 1}}, ToXY: XY{0, 3}},
 			},
 		},
 		{
@@ -191,7 +191,7 @@ func TestPawnActions(t *testing.T) {
 			xy:    XY{0, 6},
 			actions: []Action{
 				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorWhite, XY: XY{0, 6}}, ToXY: XY{0, 5}},
-				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorWhite, XY: XY{0, 6}}, ToXY: XY{0, 4}, IsEnPassant: true},
+				{FromPiece: Piece{PieceType: PiecePawn, Owner: ColorWhite, XY: XY{0, 6}}, ToXY: XY{0, 4}},
 			},
 		},
 		{

--- a/main_js.go
+++ b/main_js.go
@@ -194,7 +194,6 @@ func convertOutputAction(a api.OutputAction) map[string]interface{} {
 		"isCapture":          a.IsCapture,
 		"isResign":           a.IsResign,
 		"isPromotion":        a.IsPromotion,
-		"isEnPassant":        a.IsEnPassant,
 		"isEnPassantCapture": a.IsEnPassantCapture,
 		"isCastle":           a.IsCastle,
 		"isKingsideCastle":   a.IsKingsideCastle,

--- a/parser/notation_parser.go
+++ b/parser/notation_parser.go
@@ -23,7 +23,6 @@ type actionPattern struct {
 	isCapture          *bool
 	isResign           *bool
 	isPromotion        *bool
-	isEnPassant        *bool
 	isEnPassantCapture *bool
 	isCastle           *bool
 	isKingsideCastle   *bool
@@ -46,7 +45,6 @@ func (p actionPattern) Clone() actionPattern {
 		isCapture:          cloneBool(p.isCapture),
 		isResign:           cloneBool(p.isResign),
 		isPromotion:        cloneBool(p.isPromotion),
-		isEnPassant:        cloneBool(p.isEnPassant),
 		isEnPassantCapture: cloneBool(p.isEnPassantCapture),
 		isCastle:           cloneBool(p.isCastle),
 		isKingsideCastle:   cloneBool(p.isKingsideCastle),
@@ -103,9 +101,6 @@ func (p actionPattern) String() string {
 	if p.isPromotion != nil {
 		sb.WriteString(fmt.Sprintf("{a.isPromotion}:%v\n", *p.isPromotion))
 	}
-	if p.isEnPassant != nil {
-		sb.WriteString(fmt.Sprintf("{a.isEnPassant}:%v\n", *p.isEnPassant))
-	}
 	if p.isEnPassantCapture != nil {
 		sb.WriteString(fmt.Sprintf("{a.isEnPassantCapture}:%v\n", *p.isEnPassantCapture))
 	}
@@ -142,7 +137,6 @@ func (p *actionPattern) isMatch(a core.Action) bool {
 		!boolMatcher(p.isCapture)(a.IsCapture) ||
 		!boolMatcher(p.isResign)(a.IsResign) ||
 		!boolMatcher(p.isPromotion)(a.IsPromotion) ||
-		!boolMatcher(p.isEnPassant)(a.IsEnPassant) ||
 		!boolMatcher(p.isEnPassantCapture)(a.IsEnPassantCapture) ||
 		!boolMatcher(p.isCastle)(a.IsCastle) ||
 		!boolMatcher(p.isKingsideCastle)(a.IsKingsideCastle) ||

--- a/parser/pgn/variant_test.go
+++ b/parser/pgn/variant_test.go
@@ -24,11 +24,9 @@ func TestVariantPGN_Parse(t *testing.T) {
 	require.Equal(t, core.PieceType(core.PiecePawn), e2Pawn.PieceType)
 
 	// Do e4 to populate Actions - create a valid e4 action
-	// For a two-square pawn move, IsEnPassant should be true
 	e4Action := core.Action{
-		FromPiece:   e2Pawn,
-		ToXY:        core.XY{X: 4, Y: 4},
-		IsEnPassant: true,
+		FromPiece: e2Pawn,
+		ToXY:      core.XY{X: 4, Y: 4},
 	}
 	gameAfterE4 := initialGame.DoAction(e4Action)
 	require.NotEmpty(t, gameAfterE4.Actions, "Actions should be populated after DoAction")

--- a/printer/smith.go
+++ b/printer/smith.go
@@ -20,7 +20,7 @@ func (p SmithPrinter) PrintAction(gameStep core.GameStep, gameCharacteristics Ga
 	)
 	if gameStep.StepAction.IsCapture {
 		capture = gameStep.StepAction.CapturedPiece.PieceType.ToSmith()
-		if gameStep.StepAction.IsEnPassant {
+		if gameStep.StepAction.IsEnPassantCapture {
 			capture = "E"
 		}
 	}

--- a/printer/smith_test.go
+++ b/printer/smith_test.go
@@ -17,7 +17,7 @@ func TestSmithPrinter_PrintAction(t *testing.T) {
 		expectedResult      string
 	}{
 		{
-			name: "Test case 1",
+			name: "simple pawn move",
 			gameStep: core.GameStep{
 				StepGame: core.NewDefaultGame(),
 				StepAction: core.Action{
@@ -28,7 +28,21 @@ func TestSmithPrinter_PrintAction(t *testing.T) {
 			gameCharacteristics: GameCharacteristics{},
 			expectedResult:      "e2e4",
 		},
-		// Add more test cases here...
+		{
+			name: "en passant capture uses E indicator",
+			gameStep: core.GameStep{
+				StepGame: core.NewDefaultGame(),
+				StepAction: core.Action{
+					FromPiece:          core.Piece{PieceType: core.PiecePawn, Owner: core.ColorWhite, XY: core.XY{X: 3, Y: 3}},
+					ToXY:               core.XY{X: 2, Y: 2},
+					IsCapture:          true,
+					IsEnPassantCapture: true,
+					CapturedPiece:      core.Piece{PieceType: core.PiecePawn, Owner: core.ColorBlack, XY: core.XY{X: 2, Y: 3}},
+				},
+			},
+			gameCharacteristics: GameCharacteristics{},
+			expectedResult:      "d5c6E",
+		},
 	}
 
 	printer := SmithPrinter{}


### PR DESCRIPTION
Remove the `IsEnPassant` field from `Action`, which incorrectly labeled two-square pawn advances as "en passant" — also fixes a bug in the Smith printer that was checking `IsEnPassant` instead of `IsEnPassantCapture` for the "E" capture indicator.

Fixes #1