### PR TITLE
Add perft move-generation tests

### DIFF
--- a/core/chess.go
+++ b/core/chess.go
@@ -296,7 +296,7 @@ func (g Game) DoAction(a Action) Game {
 		return newGame
 	}
 
-	// Castling context update
+	// Castling context update: moving player's king or rook
 	switch {
 	case lastTurn == ColorBlack && (a.IsCastle || a.FromPiece.PieceType == PieceKing):
 		newGame.CanBlackCastle = false
@@ -318,6 +318,24 @@ func (g Game) DoAction(a Action) Game {
 	case lastTurn == ColorWhite && a.FromPiece.PieceType == PieceRook && a.FromPiece.XY == XY{X: 7, Y: 7}:
 		newGame.CanWhiteKingsideCastle = false
 		newGame.CanWhiteCastle = newGame.CanWhiteQueensideCastle
+	}
+
+	// Castling context update: opponent's rook captured on its home square
+	if a.IsCapture {
+		switch a.ToXY {
+		case XY{X: 0, Y: 0}:
+			newGame.CanBlackQueensideCastle = false
+			newGame.CanBlackCastle = newGame.CanBlackKingsideCastle
+		case XY{X: 7, Y: 0}:
+			newGame.CanBlackKingsideCastle = false
+			newGame.CanBlackCastle = newGame.CanBlackQueensideCastle
+		case XY{X: 0, Y: 7}:
+			newGame.CanWhiteQueensideCastle = false
+			newGame.CanWhiteCastle = newGame.CanWhiteKingsideCastle
+		case XY{X: 7, Y: 7}:
+			newGame.CanWhiteKingsideCastle = false
+			newGame.CanWhiteCastle = newGame.CanWhiteQueensideCastle
+		}
 	}
 
 	newGame.MoveNumber = g.MoveNumber + 1

--- a/core/entities.go
+++ b/core/entities.go
@@ -391,11 +391,11 @@ var (
 	}
 	unthreatenedXYsForCastlingByColorAndCastleType = map[color]map[castleType][]XY{
 		ColorBlack: {
-			castleTypeQueenside: {{1, 0}, {2, 0}, {3, 0}, {4, 0}},
+			castleTypeQueenside: {{2, 0}, {3, 0}, {4, 0}},
 			castleTypeKingside:  {{4, 0}, {5, 0}, {6, 0}},
 		},
 		ColorWhite: {
-			castleTypeQueenside: {{1, 7}, {2, 7}, {3, 7}, {4, 7}},
+			castleTypeQueenside: {{2, 7}, {3, 7}, {4, 7}},
 			castleTypeKingside:  {{4, 7}, {5, 7}, {6, 7}},
 		},
 	}

--- a/core/king_actions_test.go
+++ b/core/king_actions_test.go
@@ -294,7 +294,7 @@ func TestKingActions(t *testing.T) {
 			},
 		},
 		{
-			name: "black king: can't castle queenside because there's a square in check",
+			name: "black king: can castle queenside even though b8 is threatened (only king path matters)",
 			board: Board{
 				Board: []string{
 					"♜   ♚♝♞♜",
@@ -316,6 +316,7 @@ func TestKingActions(t *testing.T) {
 			xy:    XY{4, 0},
 			actions: []Action{
 				{FromPiece: Piece{PieceType: PieceKing, Owner: ColorBlack, XY: XY{4, 0}}, ToXY: XY{3, 0}},
+				{FromPiece: Piece{PieceType: PieceKing, Owner: ColorBlack, XY: XY{4, 0}}, ToXY: XY{2, 0}, IsCastle: true, IsQueensideCastle: true},
 			},
 		},
 		{
@@ -567,7 +568,7 @@ func TestKingActions(t *testing.T) {
 			},
 		},
 		{
-			name: "white king: can't castle queenside because there's a square in check",
+			name: "white king: can castle queenside even though b1 is threatened (only king path matters)",
 			board: Board{
 				Board: []string{
 					" ♞♝♛♚♝♞♜",
@@ -589,6 +590,7 @@ func TestKingActions(t *testing.T) {
 			xy:    XY{4, 7},
 			actions: []Action{
 				{FromPiece: Piece{PieceType: PieceKing, Owner: ColorWhite, XY: XY{4, 7}}, ToXY: XY{3, 7}},
+				{FromPiece: Piece{PieceType: PieceKing, Owner: ColorWhite, XY: XY{4, 7}}, ToXY: XY{2, 7}, IsCastle: true, IsQueensideCastle: true},
 			},
 		},
 		{

--- a/core/perft.go
+++ b/core/perft.go
@@ -1,0 +1,18 @@
+package core
+
+// Perft counts the number of leaf nodes in the move tree at the given depth.
+// It is the standard method for validating move generation correctness in chess engines.
+// https://www.chessprogramming.org/Perft
+func Perft(g Game, depth int) int {
+	if depth == 0 {
+		return 1
+	}
+	nodes := 0
+	for _, a := range g.Actions {
+		if a.IsResign {
+			continue
+		}
+		nodes += Perft(g.DoAction(a), depth-1)
+	}
+	return nodes
+}

--- a/core/perft_test.go
+++ b/core/perft_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerft(t *testing.T) {
+	ts := []struct {
+		name   string
+		fen    string
+		depths map[int]int
+	}{
+		{
+			name: "Position 1: Initial position",
+			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			depths: map[int]int{
+				0: 1,
+				1: 20,
+				2: 400,
+				3: 8902,
+				4: 197281,
+			},
+		},
+		{
+			name: "Position 2: Kiwipete",
+			fen:  "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+			depths: map[int]int{
+				1: 48,
+				2: 2039,
+				3: 97862,
+			},
+		},
+		{
+			name: "Position 3: endgame with en passant and promotion",
+			fen:  "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+			depths: map[int]int{
+				1: 14,
+				2: 191,
+				3: 2812,
+				4: 43238,
+			},
+		},
+		{
+			name: "Position 4: promotions and castling",
+			fen:  "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+			depths: map[int]int{
+				1: 6,
+				2: 264,
+				3: 9467,
+				4: 422333,
+			},
+		},
+		{
+			name: "Position 5: promotion edge cases",
+			fen:  "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+			depths: map[int]int{
+				1: 44,
+				2: 1486,
+				3: 62379,
+			},
+		},
+		{
+			name: "Position 6: mirrored evaluation",
+			fen:  "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
+			depths: map[int]int{
+				1: 46,
+				2: 2079,
+				3: 89890,
+			},
+		},
+	}
+
+	for _, tc := range ts {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+
+			for depth, expected := range tc.depths {
+				t.Run(fmt.Sprintf("depth_%d", depth), func(t *testing.T) {
+					if depth >= 4 && testing.Short() {
+						t.Skipf("skipping depth %d in short mode", depth)
+					}
+					got := Perft(g, depth)
+					require.Equal(t, expected, got, "depth %d: expected %d nodes, got %d", depth, expected, got)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add perft tests against all 6 standard CPW positions, which uncovered and fixed two castling bugs: b1/b8 incorrectly required unthreatened for queenside castling, and rook captures not revoking opponent castling rights.

Closes #25