### PR TITLE
DoAction: default promotion piece to Queen and include SAN action string

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/marianogappa/cheesse/core"
 	"github.com/marianogappa/cheesse/parser"
+	"github.com/marianogappa/cheesse/printer"
 )
 
 // API represents the cheesse API. All cheesse API methods are exported methods of this struct.
@@ -60,7 +61,14 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 	if err != nil {
 		return OutputGame{}, OutputAction{}, err
 	}
-	return mapGameToOutputGame(parsedGame.DoAction(parsedAction)), mapInternalActionToAction(parsedAction), nil
+	newGame := parsedGame.DoAction(parsedAction)
+	outputAction := mapInternalActionToAction(parsedAction)
+	actionString, err := printer.AlgebraicPrinter{}.PrintAction(core.GameStep{StepAction: parsedAction, StepGame: newGame}, printer.SANCharacteristics())
+	if err != nil {
+		return OutputGame{}, OutputAction{}, err
+	}
+	outputAction.ActionString = actionString
+	return mapGameToOutputGame(newGame), outputAction, nil
 }
 
 // ParseNotation takes any valid input game and a string representing a match in some

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -135,6 +135,10 @@ type OutputGame struct {
 // - `capturedPieceType` is one of `{Queen|King|Bishop|Knight|Rook|Pawn}`,
 // and represents the piece that was captured, if the action is a capture.
 // If the action is not a capture, it's an empty string.
+//
+// - `actionString` is the action rendered in Standard Algebraic Notation
+// (e.g. `Nf3`). It is only populated by API calls that apply the action on
+// a game (e.g. `DoAction`); otherwise it's an empty string.
 type OutputAction struct {
 	FromPieceOwner     string `json:"fromPieceOwner"`
 	FromPieceType      string `json:"fromPieceType"`
@@ -149,6 +153,7 @@ type OutputAction struct {
 	IsQueensideCastle  bool   `json:"isQueensideCastle"`
 	PromotionPieceType string `json:"promotionPieceType"`
 	CapturedPieceType  string `json:"capturedPieceType"`
+	ActionString       string `json:"actionString"`
 }
 
 // OutputGameStep is the output interface that describes a step in a parsed

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -251,6 +251,7 @@ func TestDoAction(t *testing.T) {
 				FromPieceType:   "Pawn",
 				FromPieceSquare: "e2",
 				ToSquare:        "e4",
+				ActionString:    "e4",
 			},
 		},
 		{
@@ -272,6 +273,7 @@ func TestDoAction(t *testing.T) {
 				FromPieceType:   "Pawn",
 				FromPieceSquare: "e2",
 				ToSquare:        "e4",
+				ActionString:    "e4",
 			},
 		},
 		{
@@ -295,6 +297,7 @@ func TestDoAction(t *testing.T) {
 				ToSquare:          "c8",
 				IsCastle:          true,
 				IsQueensideCastle: true,
+				ActionString:      "O-O-O",
 			},
 		},
 		{
@@ -318,6 +321,7 @@ func TestDoAction(t *testing.T) {
 				ToSquare:         "g8",
 				IsCastle:         true,
 				IsKingsideCastle: true,
+				ActionString:     "O-O",
 			},
 		},
 		{
@@ -341,6 +345,7 @@ func TestDoAction(t *testing.T) {
 				ToSquare:          "c1",
 				IsCastle:          true,
 				IsQueensideCastle: true,
+				ActionString:      "O-O-O",
 			},
 		},
 		{
@@ -364,6 +369,7 @@ func TestDoAction(t *testing.T) {
 				ToSquare:         "g1",
 				IsCastle:         true,
 				IsKingsideCastle: true,
+				ActionString:     "O-O",
 			},
 		},
 		{
@@ -387,6 +393,55 @@ func TestDoAction(t *testing.T) {
 				ToSquare:          "d7",
 				IsCapture:         true,
 				CapturedPieceType: "Bishop",
+				ActionString:      "Bxd7+",
+			},
+		},
+		{
+			name:        "promotion defaults to Queen when no promotion piece type supplied",
+			inputGame:   InputGame{FENString: "8/5P1k/8/8/8/8/8/K7 w - - 0 1"},
+			inputAction: InputAction{FromSquare: "f7", ToSquare: "f8"},
+			outputGame: OutputGame{Board: Board{Board: []string{
+				"     ♕  ",
+				"       ♚",
+				"        ",
+				"        ",
+				"        ",
+				"        ",
+				"        ",
+				"♔       ",
+			}}},
+			outputAction: OutputAction{
+				FromPieceOwner:     "White",
+				FromPieceType:      "Pawn",
+				FromPieceSquare:    "f7",
+				ToSquare:           "f8",
+				IsPromotion:        true,
+				PromotionPieceType: "Queen",
+				ActionString:       "f8=Q",
+			},
+		},
+		{
+			name:        "promotion respects explicitly supplied promotion piece type",
+			inputGame:   InputGame{FENString: "8/5P1k/8/8/8/8/8/K7 w - - 0 1"},
+			inputAction: InputAction{FromSquare: "f7", ToSquare: "f8", PromotionPieceType: "Knight"},
+			outputGame: OutputGame{Board: Board{Board: []string{
+				"     ♘  ",
+				"       ♚",
+				"        ",
+				"        ",
+				"        ",
+				"        ",
+				"        ",
+				"♔       ",
+			}}},
+			outputAction: OutputAction{
+				FromPieceOwner:     "White",
+				FromPieceType:      "Pawn",
+				FromPieceSquare:    "f7",
+				ToSquare:           "f8",
+				IsPromotion:        true,
+				PromotionPieceType: "Knight",
+				ActionString:       "f8=N+",
 			},
 		},
 	}

--- a/api/api_utils.go
+++ b/api/api_utils.go
@@ -40,6 +40,10 @@ func (a API) parseAction(ia InputAction, g core.Game) (core.Action, error) {
 	if err != nil {
 		return core.Action{}, err
 	}
+	// Board UIs often supply only from/to squares, so promotions default to Queen.
+	if promotionPieceType == core.PieceNone {
+		promotionPieceType = core.PieceQueen
+	}
 
 	for _, action := range g.Actions {
 		if action.FromPiece.XY != fromXY || action.ToXY != toXY || (action.IsPromotion && action.PromotionPieceType != promotionPieceType) {

--- a/main_js.go
+++ b/main_js.go
@@ -200,6 +200,7 @@ func convertOutputAction(a api.OutputAction) map[string]interface{} {
 		"isQueensideCastle":  a.IsQueensideCastle,
 		"promotionPieceType": a.PromotionPieceType,
 		"capturedPieceType":  a.CapturedPieceType,
+		"actionString":       a.ActionString,
 	}
 }
 

--- a/printer/notation_printer.go
+++ b/printer/notation_printer.go
@@ -34,6 +34,15 @@ func pstr(s string) *string {
 	return &s
 }
 
+// SANCharacteristics returns GameCharacteristics matching Standard Algebraic Notation,
+// which differs from the printer defaults in the castling and checkmate symbols.
+func SANCharacteristics() GameCharacteristics {
+	return GameCharacteristics{
+		usesCastlingSymbol:  pstr("O-O"),
+		usesCheckmateSymbol: pstr("#"),
+	}
+}
+
 func pbool(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
Defaults `InputAction.PromotionPieceType` to Queen when empty and adds a SAN `actionString` to `OutputAction` returned by `DoAction`. Fixes #22.