### PR TITLE
SAN printer correctness: disambiguation, standard mate symbol, e.p. destination square

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -63,7 +63,7 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 	}
 	newGame := parsedGame.DoAction(parsedAction)
 	outputAction := mapInternalActionToAction(parsedAction)
-	actionString, err := printer.AlgebraicPrinter{}.PrintAction(core.GameStep{StepAction: parsedAction, StepGame: newGame}, printer.SANCharacteristics())
+	actionString, err := printer.AlgebraicPrinter{}.PrintAction(core.GameStep{StepAction: parsedAction, StepGame: newGame, StepPreMoveGame: parsedGame}, printer.SANCharacteristics())
 	if err != nil {
 		return OutputGame{}, OutputAction{}, err
 	}

--- a/core/entities.go
+++ b/core/entities.go
@@ -298,8 +298,11 @@ func (c XY) ToICCF() string {
 	return fmt.Sprintf("%v%v", c.X+1, 8-c.Y)
 }
 
-func (c XY) ToDescriptive(turn color) string {
-	fileNames := []string{"QR", "QN", "QB", "Q", "K", "KB", "KN", "KR"} // TODO: this doesn't respect Kt characteristic
+func (c XY) ToDescriptive(turn color, useKt ...bool) string {
+	fileNames := []string{"QR", "QN", "QB", "Q", "K", "KB", "KN", "KR"}
+	if len(useKt) > 0 && useKt[0] {
+		fileNames = []string{"QR", "QKt", "QB", "Q", "K", "KB", "KKt", "KR"}
+	}
 	y := c.Y + 1
 	if turn == ColorWhite {
 		y = 8 - c.Y
@@ -402,15 +405,17 @@ var (
 )
 
 type GameStep struct {
-	StepString string
-	StepAction Action
-	StepGame   Game
+	StepString      string
+	StepAction      Action
+	StepGame        Game
+	StepPreMoveGame Game
 }
 
 func (s GameStep) Clone() GameStep {
 	return GameStep{
-		StepString: s.StepString,
-		StepAction: s.StepAction,
-		StepGame:   s.StepGame.Clone(),
+		StepString:      s.StepString,
+		StepAction:      s.StepAction,
+		StepGame:        s.StepGame.Clone(),
+		StepPreMoveGame: s.StepPreMoveGame.Clone(),
 	}
 }

--- a/parser/generic_notation_parser.go
+++ b/parser/generic_notation_parser.go
@@ -194,9 +194,10 @@ func (p *GenericNotationParser) ProcessToken(pg *ParsingGame, token *Token) erro
 				newGame := currentGame.DoAction(action)
 				newAlternative := alt.Clone()
 				newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{
-					StepString: token.Value,
-					StepAction: action,
-					StepGame:   newGame,
+					StepString:      token.Value,
+					StepAction:      action,
+					StepGame:        newGame,
+					StepPreMoveGame: currentGame,
 				})
 
 				newAlternatives = append(newAlternatives, newAlternative)
@@ -216,9 +217,10 @@ func (p *GenericNotationParser) ProcessToken(pg *ParsingGame, token *Token) erro
 		for _, alt := range pg.Alternatives {
 			newAlternative := alt.Clone()
 			newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{
-				StepString: token.Value,
-				StepAction: core.Action{},     // Empty action for result markers
-				StepGame:   alt.CurrentGame(), // Game state doesn't change
+				StepString:      token.Value,
+				StepAction:      core.Action{},     // Empty action for result markers
+				StepGame:        alt.CurrentGame(), // Game state doesn't change
+				StepPreMoveGame: alt.CurrentGame(),
 			})
 			newAlternatives = append(newAlternatives, newAlternative)
 		}

--- a/parser/notation_algebraic.go
+++ b/parser/notation_algebraic.go
@@ -119,7 +119,7 @@ func NewNotationParserAlgebraic(initialCharacteristics Characteristics) *Notatio
 						fromX:              fileToPInt(fromSquareFile),
 						toX:                fileToPInt(toSquareFile),
 						toY:                rankToPInt(toSquareRank),
-						isEnPassantCapture: pBool(strings.HasSuffix(enPassantCapture, "e.p.")),
+						isEnPassantCapture: nilOrTrue(strings.HasSuffix(enPassantCapture, "e.p.")),
 						isCapture:          pBool(true),
 						isPromotion:        pBool(false),
 						isCastle:           pBool(false),
@@ -338,6 +338,13 @@ func rankToPInt(rank string) *int {
 
 func pBool(b bool) *bool {
 	return &b
+}
+
+func nilOrTrue(b bool) *bool {
+	if !b {
+		return nil
+	}
+	return pBool(true)
 }
 
 func processThreatenSymbol(threatenSymbol string) (isCheck *bool, isCheckmate *bool, usesCheckSymbol *string, usesCheckmateSymbol *string) {

--- a/parser/notation_parser.go
+++ b/parser/notation_parser.go
@@ -228,7 +228,7 @@ func (p *gameStepParser) next(ap actionPattern, actionString string) bool {
 					continue
 				}
 				newAlternative := alternative.Clone()
-				newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{StepString: actionString, StepAction: action, StepGame: newGame})
+				newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{StepString: actionString, StepAction: action, StepGame: newGame, StepPreMoveGame: alternative.CurrentGame()})
 				newAlternatives = append(newAlternatives, newAlternative)
 			}
 		}

--- a/printer/algebraic.go
+++ b/printer/algebraic.go
@@ -22,6 +22,38 @@ func algPiece(gameStep core.GameStep, gameCharacteristics GameCharacteristics, r
 	return gameStep.StepAction.FromPiece.PieceType.ToAlgebraic()
 }
 
+func algDisambiguate(gameStep core.GameStep) string {
+	action := gameStep.StepAction
+	if action.FromPiece.PieceType == core.PiecePawn || action.FromPiece.PieceType == core.PieceKing {
+		return ""
+	}
+	var sameFile, sameRank bool
+	ambiguous := false
+	for _, other := range gameStep.StepPreMoveGame.Actions {
+		if other.IsResign || other.FromPiece.PieceType != action.FromPiece.PieceType || other.ToXY != action.ToXY || other.FromPiece.XY == action.FromPiece.XY {
+			continue
+		}
+		ambiguous = true
+		if other.FromPiece.XY.X == action.FromPiece.XY.X {
+			sameFile = true
+		}
+		if other.FromPiece.XY.Y == action.FromPiece.XY.Y {
+			sameRank = true
+		}
+	}
+	if !ambiguous {
+		return ""
+	}
+	from := action.FromPiece.XY.ToAlgebraic()
+	if sameFile && sameRank {
+		return from
+	}
+	if sameFile {
+		return from[1:2]
+	}
+	return from[0:1]
+}
+
 func algEnPassant(gameStep core.GameStep, gameCharacteristics GameCharacteristics) string {
 	if !gameStep.StepAction.IsEnPassantCapture || gameCharacteristics.usesEnPassantSymbol == nil {
 		return ""
@@ -90,10 +122,11 @@ func algCapture(gameStep core.GameStep, gameCharacteristics GameCharacteristics)
 		captureSymbol = *gameCharacteristics.usesCaptureSymbol
 	}
 	return fmt.Sprintf(
-		"%v%v%v%v%v%v%v",
+		"%v%v%v%v%v%v%v%v",
 		algPiece(gameStep, gameCharacteristics, true),
+		algDisambiguate(gameStep),
 		captureSymbol,
-		gameStep.StepAction.CapturedPiece.XY.ToAlgebraic(),
+		gameStep.StepAction.ToXY.ToAlgebraic(),
 		algEnPassant(gameStep, gameCharacteristics),
 		algPromotion(gameStep, gameCharacteristics),
 		algCheck(gameStep, gameCharacteristics),
@@ -103,8 +136,9 @@ func algCapture(gameStep core.GameStep, gameCharacteristics GameCharacteristics)
 
 func algMove(gameStep core.GameStep, gameCharacteristics GameCharacteristics) string {
 	return fmt.Sprintf(
-		"%v%v%v%v%v%v",
+		"%v%v%v%v%v%v%v",
 		algPiece(gameStep, gameCharacteristics, false),
+		algDisambiguate(gameStep),
 		gameStep.StepAction.ToXY.ToAlgebraic(),
 		algEnPassant(gameStep, gameCharacteristics),
 		algPromotion(gameStep, gameCharacteristics),
@@ -122,7 +156,6 @@ func algResign(gameStep core.GameStep, gameCharacteristics GameCharacteristics) 
 
 func (p AlgebraicPrinter) PrintAction(gameStep core.GameStep, gameCharacteristics GameCharacteristics) (string, error) {
 	gameCharacteristics = applyDefaultGameCharacteristics(gameCharacteristics)
-	// TODO: Disambiguation
 	if gameStep.StepAction.IsCastle {
 		return algCastle(gameStep, gameCharacteristics), nil
 	}

--- a/printer/algebraic_test.go
+++ b/printer/algebraic_test.go
@@ -2,10 +2,12 @@ package printer
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/marianogappa/cheesse/core"
 	"github.com/marianogappa/cheesse/parser"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,6 +94,249 @@ func TestAlgebraicPrinter_PrintGame(t *testing.T) {
 
 			if !reflect.DeepEqual(result, tc.expectedResult) {
 				t.Errorf("PrintGame returned incorrect result. Expected: %v, got: %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func buildGameStep(t *testing.T, fen string, fromSq, toSq string) core.GameStep {
+	t.Helper()
+	g, err := core.NewGameFromFEN(fen)
+	require.NoError(t, err)
+
+	from := algebraicToXY(t, fromSq)
+	to := algebraicToXY(t, toSq)
+
+	for _, action := range g.Actions {
+		if action.FromPiece.XY == from && action.ToXY == to {
+			newGame := g.DoAction(action)
+			return core.GameStep{
+				StepAction:      action,
+				StepGame:        newGame,
+				StepPreMoveGame: g,
+			}
+		}
+	}
+	t.Fatalf("no legal action from %s to %s in FEN %s", fromSq, toSq, fen)
+	return core.GameStep{}
+}
+
+func buildGameStepWithPromotion(t *testing.T, fen string, fromSq, toSq string, promoPiece core.PieceType) core.GameStep {
+	t.Helper()
+	g, err := core.NewGameFromFEN(fen)
+	require.NoError(t, err)
+
+	from := algebraicToXY(t, fromSq)
+	to := algebraicToXY(t, toSq)
+
+	for _, action := range g.Actions {
+		if action.FromPiece.XY == from && action.ToXY == to && action.PromotionPieceType == promoPiece {
+			newGame := g.DoAction(action)
+			return core.GameStep{
+				StepAction:      action,
+				StepGame:        newGame,
+				StepPreMoveGame: g,
+			}
+		}
+	}
+	t.Fatalf("no legal action from %s to %s promoting to %v in FEN %s", fromSq, toSq, promoPiece, fen)
+	return core.GameStep{}
+}
+
+func algebraicToXY(t *testing.T, sq string) core.XY {
+	t.Helper()
+	require.Len(t, sq, 2)
+	return core.XY{X: int(sq[0] - 'a'), Y: int('8' - sq[1])}
+}
+
+func TestAlgebraicPrinter_Disambiguation(t *testing.T) {
+	p := AlgebraicPrinter{}
+	gc := GameCharacteristics{}
+
+	t.Run("two knights different files", func(t *testing.T) {
+		// Knights at d2 and f2 both can reach e4
+		gs := buildGameStep(t, "4k3/8/8/8/8/8/3N1N2/4K3 w - - 0 1", "d2", "e4")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "Nde4", result)
+	})
+
+	t.Run("disambiguation not needed when only one piece can reach the square", func(t *testing.T) {
+		gs := buildGameStep(t, "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", "g1", "f3")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "Nf3", result)
+	})
+
+	t.Run("two rooks same rank different files", func(t *testing.T) {
+		// King at a2, rooks at a1 and h1 — both can reach d1
+		gs := buildGameStep(t, "3k4/8/8/8/8/8/K7/R6R w - - 0 1", "h1", "d1")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "Rhd1+", result)
+	})
+
+	t.Run("two rooks same file need rank disambiguation", func(t *testing.T) {
+		// Rooks at a1 and a8, king at h1
+		gs := buildGameStep(t, "R2k4/8/8/8/8/8/8/R6K w - - 0 1", "a1", "a4")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "R1a4+", result)
+	})
+
+	t.Run("no disambiguation for pawns", func(t *testing.T) {
+		gs := buildGameStep(t, "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", "e2", "e4")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "e4", result)
+	})
+
+	t.Run("no disambiguation for kings", func(t *testing.T) {
+		gs := buildGameStep(t, "4k3/8/8/8/8/8/8/4K3 w - - 0 1", "e1", "e2")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "Ke2", result)
+	})
+}
+
+func TestAlgebraicPrinter_EnPassant(t *testing.T) {
+	p := AlgebraicPrinter{}
+	gc := GameCharacteristics{}
+
+	t.Run("en passant prints destination square not captured pawn square", func(t *testing.T) {
+		gs := buildGameStep(t, "rnbqkbnr/pppp1ppp/8/4pP2/8/8/PPPPP1PP/RNBQKBNR w KQkq e6 0 1", "f5", "e6")
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "fxe6 e.p.", result)
+	})
+}
+
+func TestAlgebraicPrinter_CheckmateSymbol(t *testing.T) {
+	p := AlgebraicPrinter{}
+
+	t.Run("default checkmate symbol is #", func(t *testing.T) {
+		// Scholar's mate final move: Qxf7#
+		gs := buildGameStep(t, "r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 4 3", "h5", "f7")
+		result, err := p.PrintAction(gs, GameCharacteristics{})
+		require.NoError(t, err)
+		assert.Equal(t, "Qxf7#", result)
+	})
+}
+
+func TestAlgebraicPrinter_Promotion(t *testing.T) {
+	p := AlgebraicPrinter{}
+	gc := GameCharacteristics{}
+
+	t.Run("promotion to queen", func(t *testing.T) {
+		gs := buildGameStepWithPromotion(t, "8/5P1k/8/8/8/8/8/K7 w - - 0 1", "f7", "f8", core.PieceQueen)
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "f8=Q", result)
+	})
+
+	t.Run("promotion to knight with check", func(t *testing.T) {
+		gs := buildGameStepWithPromotion(t, "8/5P1k/8/8/8/8/8/K7 w - - 0 1", "f7", "f8", core.PieceKnight)
+		result, err := p.PrintAction(gs, gc)
+		require.NoError(t, err)
+		assert.Equal(t, "f8=N+", result)
+	})
+}
+
+func TestAlgebraicPrinter_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name string
+		game string
+	}{
+		{
+			name: "French Defense opening",
+			game: `1. e4 e6
+				2. d4 d5
+				3. Nc3 Bb4
+				4. Bb5+ Bd7
+				5. Bxd7+ Qxd7
+				6. Ne2 dxe4
+				7. 0-0`,
+		},
+		{
+			name: "Scholar's mate",
+			game: `1. e4 e5
+				2. Bc4 Nc6
+				3. Qh5 Nf6
+				4. Qxf7#`,
+		},
+		{
+			name: "Italian Game with castling",
+			game: `1. e4 e5
+				2. Nf3 Nc6
+				3. Bc4 Bc5
+				4. 0-0 Nf6
+				5. d3 0-0`,
+		},
+		{
+			name: "Game with en passant",
+			game: `1. e4 Nf6
+				2. e5 d5
+				3. exd6`,
+		},
+		{
+			name: "Game with promotion",
+			game: `1. d4 c5
+				2. d5 e6
+				3. dxe6 d5
+				4. exf7+ Kd7
+				5. fxg8=N`,
+		},
+		{
+			name: "Ruy Lopez with knight disambiguation",
+			game: `1. e4 e5
+				2. Nf3 Nc6
+				3. Bb5 a6
+				4. Ba4 Nf6
+				5. O-O Be7
+				6. Re1 b5
+				7. Bb3 O-O
+				8. c3 d5`,
+		},
+		{
+			name: "Queen's Gambit Accepted",
+			game: `1. d4 d5
+				2. c4 dxc4
+				3. Nf3 Nf6
+				4. e3 e6
+				5. Bxc4 c5
+				6. O-O a6`,
+		},
+	}
+
+	p := AlgebraicPrinter{}
+	roundTripGC := SANCharacteristics()
+	roundTripGC.usesEnPassantSymbol = pstr("")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := core.NewDefaultGame()
+			gameSteps, err := parser.NewNotationParserAlgebraic(parser.Characteristics{}).Parse(g, tc.game)
+			require.NoError(t, err, "failed to parse original game")
+
+			printed, err := p.PrintGame(gameSteps, roundTripGC)
+			require.NoError(t, err, "failed to print game")
+
+			printedStr := strings.Join(printed, "\n")
+			reParsed, err := parser.NewNotationParserAlgebraic(parser.Characteristics{}).Parse(g, printedStr)
+			require.NoError(t, err, "failed to re-parse printed game: %s", printedStr)
+
+			require.Len(t, reParsed, len(gameSteps), "move count mismatch after round-trip")
+
+			for i, orig := range gameSteps {
+				final := reParsed[i]
+				assert.Equal(t, orig.StepAction.FromPiece.XY, final.StepAction.FromPiece.XY,
+					"Move %d: from square mismatch", i+1)
+				assert.Equal(t, orig.StepAction.ToXY, final.StepAction.ToXY,
+					"Move %d: to square mismatch", i+1)
+				assert.Equal(t, orig.StepAction.FromPiece.PieceType, final.StepAction.FromPiece.PieceType,
+					"Move %d: piece type mismatch", i+1)
+				assert.Equal(t, orig.StepGame.ToFEN(), final.StepGame.ToFEN(),
+					"Move %d: resulting FEN mismatch", i+1)
 			}
 		})
 	}

--- a/printer/descriptive.go
+++ b/printer/descriptive.go
@@ -12,8 +12,12 @@ func (p DescriptivePrinter) PrintGame(gameSteps []core.GameStep, gameCharacteris
 	return genericGamePrinter(gameSteps, gameCharacteristics, p)
 }
 
+func descUseKt(gc GameCharacteristics) bool {
+	return gc.descriptiveUseKt != nil && *gc.descriptiveUseKt
+}
+
 func piece(gameStep core.GameStep, gameCharacteristics GameCharacteristics, renderFileIfPawn bool) string {
-	return gameStep.StepAction.FromPiece.PieceType.ToDescriptive(gameCharacteristics.descriptiveUseKt != nil && *gameCharacteristics.descriptiveUseKt)
+	return gameStep.StepAction.FromPiece.PieceType.ToDescriptive(descUseKt(gameCharacteristics))
 }
 
 func enPassant(gameStep core.GameStep, gameCharacteristics GameCharacteristics) string {
@@ -88,11 +92,11 @@ func capture(gameStep core.GameStep, gameCharacteristics GameCharacteristics) st
 		"%v%v%v%v%v%v%v",
 		piece(gameStep, gameCharacteristics, true),
 		captureSymbol,
-		gameStep.StepAction.CapturedPiece.XY.ToDescriptive(gameStep.StepGame.Turn()),
+		gameStep.StepAction.ToXY.ToDescriptive(gameStep.StepGame.Turn(), descUseKt(gameCharacteristics)),
 		enPassant(gameStep, gameCharacteristics),
 		promotion(gameStep, gameCharacteristics),
-		algCheck(gameStep, gameCharacteristics),
-		algCheckmate(gameStep, gameCharacteristics),
+		check(gameStep, gameCharacteristics),
+		checkmate(gameStep, gameCharacteristics),
 	)
 }
 
@@ -100,7 +104,7 @@ func move(gameStep core.GameStep, gameCharacteristics GameCharacteristics) strin
 	return fmt.Sprintf(
 		"%v-%v%v%v%v%v",
 		piece(gameStep, gameCharacteristics, false),
-		gameStep.StepAction.ToXY.ToDescriptive(gameStep.StepGame.Turn().Opponent()), // N.B. because game is after doing the action
+		gameStep.StepAction.ToXY.ToDescriptive(gameStep.StepGame.Turn().Opponent(), descUseKt(gameCharacteristics)),
 		enPassant(gameStep, gameCharacteristics),
 		promotion(gameStep, gameCharacteristics),
 		check(gameStep, gameCharacteristics),

--- a/printer/notation_printer.go
+++ b/printer/notation_printer.go
@@ -38,8 +38,7 @@ func pstr(s string) *string {
 // which differs from the printer defaults in the castling and checkmate symbols.
 func SANCharacteristics() GameCharacteristics {
 	return GameCharacteristics{
-		usesCastlingSymbol:  pstr("O-O"),
-		usesCheckmateSymbol: pstr("#"),
+		usesCastlingSymbol: pstr("O-O"),
 	}
 }
 
@@ -52,7 +51,7 @@ func applyDefaultGameCharacteristics(gameCharacteristics GameCharacteristics) Ga
 		gameCharacteristics.usesCheckSymbol = pstr("+")
 	}
 	if gameCharacteristics.usesCheckmateSymbol == nil {
-		gameCharacteristics.usesCheckmateSymbol = pstr("++")
+		gameCharacteristics.usesCheckmateSymbol = pstr("#")
 	}
 	if gameCharacteristics.usesFullMoveDot == nil {
 		gameCharacteristics.usesFullMoveDot = pbool(true)


### PR DESCRIPTION
Fixes algebraic disambiguation, default checkmate symbol (++ → #), en-passant capture destination, and descriptive printer Kt/check bugs. Fixes #28.