### PR TITLE
Parsers: make disambiguation mandatory for ambiguous action strings

### DIFF
--- a/parser/notation_algebraic_test.go
+++ b/parser/notation_algebraic_test.go
@@ -1355,7 +1355,7 @@ func TestNotationParserAlgebraic(t *testing.T) {
 		{
 			fen: "8/7K/7P/1P6/2n4k/4n3/1P6/8 w - - 0 1",
 			s: `1. Kg6  Ne5+
-				2. Kf6  Ng4+
+				2. Kf6  N5g4+
 				3. Ke6  Nxh6
 				4. b6 Nf7
 				5. Kxf7 Nc4
@@ -3735,7 +3735,7 @@ func TestNotationParserAlgebraic(t *testing.T) {
 			s: `1. Ne4 Nd3
 				2. Qf2! Nxf2
 				3. Ng3+ Kg1
-				4. Ng5 Ng4
+				4. Ng5 Nhg4
 				5. Nf3#`,
 			expectedFEN: "8/K7/8/8/6n1/5NN1/5np1/6k1 b - - 5 5",
 			expectedErr: nil,
@@ -4013,13 +4013,13 @@ func TestNotationParserAlgebraic(t *testing.T) {
 		},
 		{
 			fen: "RK6/8/1k6/7R/8/8/pp6/8 w - - 0 1",
-			s: `1. Ra5  Kc6
+			s: `1. Raa5  Kc6
 				2. Kc8  Kd6
 				3. Kd8  Ke6
 				4. Ra6+   Kf7
 				5. Rf5+   Kg7
 				6. Rg5+   Kf7
-				7. Rg6  b1=Q
+				7. Rgg6  b1=Q
 				8. Rf6# `,
 			expectedFEN: "3K4/5k2/5RR1/8/8/8/p7/1q6 b - - 1 8",
 			expectedErr: nil,

--- a/parser/notation_ambiguity_test.go
+++ b/parser/notation_ambiguity_test.go
@@ -1,0 +1,131 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotationParserAlgebraicAmbiguity(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fen         string
+		s           string
+		expectError bool
+	}{
+		{
+			name:        "two knights reaching the same square require disambiguation",
+			fen:         "4k3/8/8/8/8/8/3N1N2/4K3 w - - 0 1",
+			s:           "1. Ne4",
+			expectError: true,
+		},
+		{
+			name:        "file disambiguation resolves two knights",
+			fen:         "4k3/8/8/8/8/8/3N1N2/4K3 w - - 0 1",
+			s:           "1. Nde4",
+			expectError: false,
+		},
+		{
+			name:        "two rooks on same rank require disambiguation",
+			fen:         "3k4/8/8/8/8/8/K7/R6R w - - 0 1",
+			s:           "1. Rd1",
+			expectError: true,
+		},
+		{
+			name:        "file disambiguation resolves two rooks on same rank",
+			fen:         "3k4/8/8/8/8/8/K7/R6R w - - 0 1",
+			s:           "1. Rhd1",
+			expectError: false,
+		},
+		{
+			name:        "two rooks on same file require rank disambiguation",
+			fen:         "R2k4/8/8/8/8/8/8/R6K w - - 0 1",
+			s:           "1. Ra4",
+			expectError: true,
+		},
+		{
+			name:        "rank disambiguation resolves two rooks on same file",
+			fen:         "R2k4/8/8/8/8/8/8/R6K w - - 0 1",
+			s:           "1. R1a4",
+			expectError: false,
+		},
+		{
+			name:        "unambiguous knight move parses fine",
+			fen:         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			s:           "1. Nf3",
+			expectError: false,
+		},
+		{
+			name:        "two knights capturing the same piece require disambiguation",
+			fen:         "4k3/8/8/8/4p3/8/3N1N2/4K3 w - - 0 1",
+			s:           "1. Nxe4",
+			expectError: true,
+		},
+		{
+			name:        "file disambiguation resolves two knights capturing the same piece",
+			fen:         "4k3/8/8/8/4p3/8/3N1N2/4K3 w - - 0 1",
+			s:           "1. Ndxe4",
+			expectError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := core.NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+			_, err = NewNotationParserAlgebraic(Characteristics{}).Parse(g, tc.s)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "ambiguous")
+				assert.Contains(t, err.Error(), "please disambiguate")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNotationParserDescriptiveAmbiguity(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fen         string
+		s           string
+		expectError bool
+	}{
+		{
+			name: "two rooks reaching the same square require disambiguation",
+			// Rooks on QR1 (a1) and KR1 (h1); R-Q1 (d1) is reachable by both.
+			fen:         "3k4/8/8/8/8/8/K7/R6R w - - 0 1",
+			s:           "1. R-Q1",
+			expectError: true,
+		},
+		{
+			name: "unambiguous rook move parses fine",
+			// Only the KR1 (h1) rook can reach KR5 (h5).
+			fen:         "3k4/8/8/8/8/8/K7/R6R w - - 0 1",
+			s:           "1. R-KR5",
+			expectError: false,
+		},
+		{
+			name:        "unambiguous pawn move parses fine",
+			fen:         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			s:           "1. P-K4",
+			expectError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := core.NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+			_, err = NewNotationParserDescriptive(Characteristics{}).Parse(g, tc.s)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "ambiguous")
+				assert.Contains(t, err.Error(), "please disambiguate")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/parser/notation_parser.go
+++ b/parser/notation_parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/marianogappa/cheesse/core"
@@ -215,6 +216,38 @@ func newGameStepParser(initialGame core.Game) *gameStepParser {
 	}
 }
 
+// matchingActions returns the distinct actions that the given pattern matches on the
+// current alternatives, applying the same post-move check/checkmate filters as next(),
+// without advancing the parser.
+func (p *gameStepParser) matchingActions(ap actionPattern) []core.Action {
+	var (
+		matched   = []core.Action{}
+		actionSet = map[core.Action]struct{}{}
+	)
+	for _, alternative := range p.alternatives {
+		for _, action := range alternative.CurrentGame().Actions {
+			if !ap.isMatch(action) {
+				continue
+			}
+			if ap.isCheck != nil || ap.isCheckmate != nil {
+				newGame := alternative.CurrentGame().DoAction(action)
+				if ap.isCheck != nil && newGame.IsCheck != *ap.isCheck {
+					continue
+				}
+				if ap.isCheckmate != nil && newGame.IsCheckmate != *ap.isCheckmate {
+					continue
+				}
+			}
+			if _, ok := actionSet[action]; ok {
+				continue
+			}
+			actionSet[action] = struct{}{}
+			matched = append(matched, action)
+		}
+	}
+	return matched
+}
+
 func (p *gameStepParser) next(ap actionPattern, actionString string) bool {
 	newAlternatives := []GameAlternative{}
 	for _, alternative := range p.alternatives {
@@ -323,6 +356,33 @@ func (p *NotationParser) Parse(initialGame core.Game, s string) ([]core.GameStep
 
 		// Move steps will advance the game
 		if stepOrder[stepI] == "move" {
+			// If the action string matches more than one action, it's ambiguous:
+			// disambiguation is mandatory, so fail describing the conflicting actions.
+			var (
+				distinctActions = []core.Action{}
+				actionSet       = map[core.Action]struct{}{}
+				ambiguousMatch  string
+			)
+			for _, tm := range tokenMatches {
+				for _, action := range p.stepParser.matchingActions(*tm.ap) {
+					if _, ok := actionSet[action]; ok {
+						continue
+					}
+					actionSet[action] = struct{}{}
+					distinctActions = append(distinctActions, action)
+					ambiguousMatch = tm.match
+				}
+			}
+			if len(distinctActions) > 1 {
+				descriptions := make([]string, len(distinctActions))
+				for j, action := range distinctActions {
+					descriptions[j] = action.String()
+				}
+				sort.Strings(descriptions)
+				err := fmt.Errorf("at index %v the action string %q is ambiguous because %v different actions match it: [%v]; please disambiguate", i, ambiguousMatch, len(distinctActions), strings.Join(descriptions, "; "))
+				return p.stepParser.parsedGame.GameSteps, err
+			}
+
 			var ok bool
 			for _, tm := range tokenMatches {
 				if ok = p.stepParser.next(*tm.ap, tm.match); ok {


### PR DESCRIPTION
Parsing now fails with a descriptive error when an action string matches more than one legal action, instead of silently picking the first match. Fixes #3.