### PR TITLE
ParseNotation: auto-detect notation and support partial parses

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -73,47 +73,27 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 }
 
 // ParseNotation takes any valid input game and a string representing a match in some
-// notation, parses them and attempts to play the match starting from the supplied
-// game. If it fails, it returns an error describing the problem.
+// notation, auto-detects the notation and attempts to play the match starting from
+// the supplied game.
 //
-// If parsing the match succeeds, it returns the parsed initial game and a list of
-// steps, one per action in the `notationString`.
+// The notation is auto-detected across all supported notations: Algebraic/SAN
+// (including figurine and PGN), Coordinate, Descriptive, ICCF and Smith. All
+// supported notations are attempted, and the attempt that parses the furthest wins.
+//
+// Partial parses are supported: if the notation string stops being valid at some
+// point, the result still contains the valid prefix of steps, the count of valid
+// actions, the name of the most likely notation, and a description of the parse
+// failure.
 //
 // An example `notationString` (Scholar's mate):
 //
 // `1. e4 e5\n2. Bc4 Nc6\n3. Qh5 Nf6??\n4. Qxf7#`
 //
-// The notation is auto-detected across all supported notations: Algebraic/SAN
-// (including figurine and PGN), Coordinate, Descriptive, ICCF and Smith.
-//
-// Please refer to InputGame's, OutputGame's and OutputGameStep's docs for format
-// details.
-func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, []OutputGameStep, error) {
-	outputGame, result, err := a.ParseNotationDetailed(game, notationString)
-	if err != nil {
-		return OutputGame{}, []OutputGameStep{}, err
-	}
-	if !result.ParseWasSuccessful {
-		return outputGame, result.Steps, errors.New(result.Error)
-	}
-	return outputGame, result.Steps, nil
-}
-
-// ParseNotationDetailed takes any valid input game and a string representing a match
-// in some notation, auto-detects the notation and attempts to play the match starting
-// from the supplied game.
-//
-// Unlike ParseNotation, it supports partial parses: if the notation string stops being
-// valid at some point, the result still contains the valid prefix of steps, the count
-// of valid actions, the name of the most likely notation, and a description of the
-// parse failure. All supported notations are attempted, and the attempt that parses
-// the furthest wins.
-//
 // An error is only returned if the input game itself is invalid.
 //
 // Please refer to InputGame's, OutputGame's, OutputGameStep's and OutputParseResult's
 // docs for format details.
-func (a API) ParseNotationDetailed(game InputGame, notationString string) (OutputGame, OutputParseResult, error) {
+func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, OutputParseResult, error) {
 	parsedGame, err := a.parseGame(game)
 	if err != nil {
 		return OutputGame{}, OutputParseResult{}, err

--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/marianogappa/cheesse/core"
 	"github.com/marianogappa/cheesse/parser"
+	"github.com/marianogappa/cheesse/parser/pgn"
 	"github.com/marianogappa/cheesse/printer"
 )
 
@@ -82,31 +83,94 @@ func (a API) DoAction(game InputGame, action InputAction) (OutputGame, OutputAct
 //
 // `1. e4 e5\n2. Bc4 Nc6\n3. Qh5 Nf6??\n4. Qxf7#`
 //
-// At the moment, only Algebraic and ICCF Notations are supported, but support for most
-// notations is planned at a later release.
+// The notation is auto-detected across all supported notations: Algebraic/SAN
+// (including figurine and PGN), Coordinate, Descriptive, ICCF and Smith.
 //
 // Please refer to InputGame's, OutputGame's and OutputGameStep's docs for format
 // details.
 func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, []OutputGameStep, error) {
-	parsedGame, err := a.parseGame(game)
+	outputGame, result, err := a.ParseNotationDetailed(game, notationString)
 	if err != nil {
 		return OutputGame{}, []OutputGameStep{}, err
 	}
+	if !result.ParseWasSuccessful {
+		return outputGame, result.Steps, errors.New(result.Error)
+	}
+	return outputGame, result.Steps, nil
+}
 
-	notationParsers := []*parser.NotationParser{
-		parser.NewNotationParserAlgebraic(parser.Characteristics{}),
-		parser.NewNotationParserICCF(parser.Characteristics{}),
-		parser.NewNotationParserSmith(parser.Characteristics{}),
-		parser.NewNotationParserCoordinate(parser.Characteristics{}),
+// ParseNotationDetailed takes any valid input game and a string representing a match
+// in some notation, auto-detects the notation and attempts to play the match starting
+// from the supplied game.
+//
+// Unlike ParseNotation, it supports partial parses: if the notation string stops being
+// valid at some point, the result still contains the valid prefix of steps, the count
+// of valid actions, the name of the most likely notation, and a description of the
+// parse failure. All supported notations are attempted, and the attempt that parses
+// the furthest wins.
+//
+// An error is only returned if the input game itself is invalid.
+//
+// Please refer to InputGame's, OutputGame's, OutputGameStep's and OutputParseResult's
+// docs for format details.
+func (a API) ParseNotationDetailed(game InputGame, notationString string) (OutputGame, OutputParseResult, error) {
+	parsedGame, err := a.parseGame(game)
+	if err != nil {
+		return OutputGame{}, OutputParseResult{}, err
 	}
 
-	var gameSteps []core.GameStep
-	for _, notationParser := range notationParsers {
-		gameSteps, err = notationParser.Parse(parsedGame, notationString)
-		if err == nil {
-			break
+	type notationCandidate struct {
+		name  string
+		parse func() ([]core.GameStep, error)
+	}
+	candidates := []notationCandidate{
+		{"Algebraic Notation", func() ([]core.GameStep, error) {
+			return parser.NewNotationParserAlgebraic(parser.Characteristics{}).Parse(parsedGame, notationString)
+		}},
+		{"ICCF Notation", func() ([]core.GameStep, error) {
+			return parser.NewNotationParserICCF(parser.Characteristics{}).Parse(parsedGame, notationString)
+		}},
+		{"Smith Notation", func() ([]core.GameStep, error) {
+			return parser.NewNotationParserSmith(parser.Characteristics{}).Parse(parsedGame, notationString)
+		}},
+		{"Coordinate Notation", func() ([]core.GameStep, error) {
+			return parser.NewNotationParserCoordinate(parser.Characteristics{}).Parse(parsedGame, notationString)
+		}},
+		{"Descriptive Notation", func() ([]core.GameStep, error) {
+			return parser.NewNotationParserDescriptive(parser.Characteristics{}).Parse(parsedGame, notationString)
+		}},
+		{"PGN", func() ([]core.GameStep, error) {
+			parsed, err := parser.NewGenericNotationParser(pgn.NewVariantPGN()).Parse(parsedGame, notationString)
+			if parsed == nil {
+				return nil, err
+			}
+			return parsed.GameSteps, err
+		}},
+	}
+
+	var best *OutputParseResult
+	for _, candidate := range candidates {
+		gameSteps, err := candidate.parse()
+		validSteps := len(gameSteps)
+		result := OutputParseResult{
+			NotationName:       candidate.name,
+			ParseWasSuccessful: err == nil,
+			ValidActionCount:   validSteps,
+			Steps:              mapGameStepsToOutputGameSteps(gameSteps),
+		}
+		if err != nil {
+			result.Error = err.Error()
+		}
+
+		// A fully-successful parse with at least one step wins immediately.
+		if result.ParseWasSuccessful && validSteps > 0 {
+			return mapGameToOutputGame(parsedGame), result, nil
+		}
+		// Otherwise keep the attempt that parsed the furthest.
+		if best == nil || validSteps > best.ValidActionCount {
+			best = &result
 		}
 	}
 
-	return mapGameToOutputGame(parsedGame), mapGameStepsToOutputGameSteps(gameSteps), err
+	return mapGameToOutputGame(parsedGame), *best, nil
 }

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -158,6 +158,29 @@ type OutputAction struct {
 	ActionString       string `json:"actionString"`
 }
 
+// OutputParseResult is the output interface that describes the result of
+// auto-detecting and parsing a match in some notation.
+//
+// - `notationName` is the name of the notation that parsed the furthest (the
+// most likely notation of the input), e.g. `Algebraic Notation`.
+//
+// - `parseWasSuccessful` is true if the whole notation string was parsed.
+//
+// - `validActionCount` is the number of valid actions parsed before either the
+// end of the input or the first invalid action.
+//
+// - `steps` contains one OutputGameStep per valid action, even if the parse
+// failed midway: clients can render the valid prefix and flag the invalid tail.
+//
+// - `error` describes why the parse stopped, when `parseWasSuccessful` is false.
+type OutputParseResult struct {
+	NotationName       string           `json:"notationName"`
+	ParseWasSuccessful bool             `json:"parseWasSuccessful"`
+	ValidActionCount   int              `json:"validActionCount"`
+	Steps              []OutputGameStep `json:"steps"`
+	Error              string           `json:"error,omitempty"`
+}
+
 // OutputGameStep is the output interface that describes a step in a parsed
 // or converted match in a given notation string.
 //

--- a/api/parse_notation_test.go
+++ b/api/parse_notation_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The same French Defense game in all six supported notations (ostinato's
+// six-notation suite), all ending at the same final position.
+const sixNotationsFinalFEN = "rn2k1nr/pppq1ppp/4p3/8/1b1Pp3/2N5/PPP1NPPP/R1BQ1RK1 b kq - 1 7"
+
+var sixNotationGames = []struct {
+	notationName string
+	game         string
+}{
+	{"Algebraic Notation", `1. e4 e6
+2. d4 d5
+3. Nc3 Bb4
+4. Bb5+ Bd7
+5. Bxd7+ Qxd7
+6. Ne2 dxe4
+7. 0-0`},
+	{"Algebraic Notation", `1. e4 e6
+2. d4 d5
+3. ♘c3 ♝b4
+4. ♗b5+ ♝d7
+5. ♗xd7+ ♛xd7
+6. ♘ge2 dxe4
+7. 0-0`}, // Figurine is a variant of Algebraic
+	{"ICCF Notation", `1. 5254 5756
+2. 4244 4745
+3. 2133 6824
+4. 6125 3847
+5. 2547 4847
+6. 7152 4554
+7. 5171`},
+	{"Smith Notation", `1. e2e4  e7e6
+2. d2d4  d7d5
+3. b1c3  f8b4
+4. f1b5  c8d7
+5. b5d7b d8d7b
+6. g1e2  d5e4p
+7. e1g1c`},
+	{"Coordinate Notation", `1. e2-e4 e7-e6
+2. d2-d4 d7-d5
+3. b1-c3 f8-b4
+4. f1-b5+ c8-d7
+5. b5xd7+ d8xd7
+6. g1-e2 d5xe4
+7. 0-0`},
+	{"Descriptive Notation", `1. P-K4 P-K3
+2. P-Q4 P-Q4
+3. N-QB3 B-N5
+4. B-N5ch B-Q2
+5. BxBch QxB
+6. KN-K2 PxP
+7. 0-0`},
+	{"PGN", `[Event "Ostinato Testing"]
+[Site "Buenos Aires, Argentina"]
+[Date "2015.??.??"]
+[Round "1"]
+[Result "1/2-1/2"]
+[White "Fake Player 1"]
+[Black "Fake Player 2"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. Bb5+ Bd7 5. Bxd7+ Qxd7 6. Nge2
+dxe4 7. 0-0`},
+}
+
+func TestParseNotationDetailed_AutoDetectsSixNotations(t *testing.T) {
+	for _, tc := range sixNotationGames {
+		t.Run(tc.notationName+" / "+tc.game[:20], func(t *testing.T) {
+			_, result, err := New().ParseNotationDetailed(InputGame{}, tc.game)
+			require.NoError(t, err)
+			assert.True(t, result.ParseWasSuccessful, "parse should succeed; error: %v", result.Error)
+			assert.Equal(t, tc.notationName, result.NotationName)
+			require.NotEmpty(t, result.Steps)
+			// PGN games may end with a result-marker step whose game is unchanged;
+			// find the last step with the expected final position.
+			lastStep := result.Steps[len(result.Steps)-1]
+			assert.Equal(t, sixNotationsFinalFEN, lastStep.Game.FENString)
+		})
+	}
+}
+
+func TestParseNotationDetailed_PartialParse(t *testing.T) {
+	t.Run("invalid move mid-game returns valid prefix", func(t *testing.T) {
+		// Qh7 on move 3 is illegal (queen can't reach h7)
+		game := "1. e4 e5\n2. Bc4 Nc6\n3. Qh7 Nf6"
+		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		require.NoError(t, err)
+		assert.False(t, result.ParseWasSuccessful)
+		assert.Equal(t, "Algebraic Notation", result.NotationName)
+		assert.Equal(t, 4, result.ValidActionCount, "e4, e5, Bc4, Nc6 are valid")
+		assert.Len(t, result.Steps, 4)
+		assert.NotEmpty(t, result.Error)
+	})
+
+	t.Run("garbage input returns zero valid actions", func(t *testing.T) {
+		_, result, err := New().ParseNotationDetailed(InputGame{}, "hello world this is not chess")
+		require.NoError(t, err)
+		assert.False(t, result.ParseWasSuccessful)
+		assert.Equal(t, 0, result.ValidActionCount)
+		assert.Empty(t, result.Steps)
+		assert.NotEmpty(t, result.Error)
+	})
+
+	t.Run("truncated ICCF game returns valid prefix", func(t *testing.T) {
+		// Third move 9999 is invalid ICCF
+		game := "1. 5254 5755\n2. 9999"
+		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		require.NoError(t, err)
+		assert.False(t, result.ParseWasSuccessful)
+		assert.Equal(t, 2, result.ValidActionCount)
+		assert.Len(t, result.Steps, 2)
+	})
+
+	t.Run("descriptive game with invalid tail returns valid prefix and notation name", func(t *testing.T) {
+		game := "1. P-K4 P-K3\n2. P-Q4 P-Q9"
+		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		require.NoError(t, err)
+		assert.False(t, result.ParseWasSuccessful)
+		assert.Equal(t, "Descriptive Notation", result.NotationName)
+		assert.Equal(t, 3, result.ValidActionCount, "P-K4, P-K3, P-Q4 are valid")
+	})
+}
+
+func TestParseNotationDetailed_CustomInitialPosition(t *testing.T) {
+	// Chernev Game 1 starting position
+	inputGame := InputGame{FENString: "8/8/8/8/8/1k5P/8/2K5 w - - 0 1"}
+	game := "1. P-R4 K-B5\n2. P-R5 K-Q4"
+	_, result, err := New().ParseNotationDetailed(inputGame, game)
+	require.NoError(t, err)
+	assert.True(t, result.ParseWasSuccessful, "error: %v", result.Error)
+	assert.Equal(t, "Descriptive Notation", result.NotationName)
+	assert.Equal(t, 4, result.ValidActionCount)
+}
+
+func TestParseNotationDetailed_InvalidInputGame(t *testing.T) {
+	_, _, err := New().ParseNotationDetailed(InputGame{FENString: "not a fen"}, "1. e4")
+	require.Error(t, err)
+}
+
+func TestParseNotation_BackwardsCompatible(t *testing.T) {
+	t.Run("successful parse returns steps and no error", func(t *testing.T) {
+		_, steps, err := New().ParseNotation(InputGame{}, "1. e4 e5\n2. Nf3")
+		require.NoError(t, err)
+		assert.Len(t, steps, 3)
+	})
+
+	t.Run("failed parse returns error", func(t *testing.T) {
+		_, _, err := New().ParseNotation(InputGame{}, "not a chess game at all")
+		require.Error(t, err)
+	})
+}
+
+func TestParseNotationDetailed_ActionStrings(t *testing.T) {
+	// The steps should carry the original action strings for frontend display
+	_, result, err := New().ParseNotationDetailed(InputGame{}, "1. e4 e5\n2. Nf3 Nc6")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 4)
+	assert.Equal(t, "e4", result.Steps[0].ActionString)
+	assert.Equal(t, "e5", result.Steps[1].ActionString)
+	assert.Equal(t, "Nf3", result.Steps[2].ActionString)
+	assert.Equal(t, "Nc6", result.Steps[3].ActionString)
+}

--- a/api/parse_notation_test.go
+++ b/api/parse_notation_test.go
@@ -69,10 +69,10 @@ var sixNotationGames = []struct {
 dxe4 7. 0-0`},
 }
 
-func TestParseNotationDetailed_AutoDetectsSixNotations(t *testing.T) {
+func TestParseNotation_AutoDetectsSixNotations(t *testing.T) {
 	for _, tc := range sixNotationGames {
 		t.Run(tc.notationName+" / "+tc.game[:20], func(t *testing.T) {
-			_, result, err := New().ParseNotationDetailed(InputGame{}, tc.game)
+			_, result, err := New().ParseNotation(InputGame{}, tc.game)
 			require.NoError(t, err)
 			assert.True(t, result.ParseWasSuccessful, "parse should succeed; error: %v", result.Error)
 			assert.Equal(t, tc.notationName, result.NotationName)
@@ -85,11 +85,11 @@ func TestParseNotationDetailed_AutoDetectsSixNotations(t *testing.T) {
 	}
 }
 
-func TestParseNotationDetailed_PartialParse(t *testing.T) {
+func TestParseNotation_PartialParse(t *testing.T) {
 	t.Run("invalid move mid-game returns valid prefix", func(t *testing.T) {
 		// Qh7 on move 3 is illegal (queen can't reach h7)
 		game := "1. e4 e5\n2. Bc4 Nc6\n3. Qh7 Nf6"
-		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		_, result, err := New().ParseNotation(InputGame{}, game)
 		require.NoError(t, err)
 		assert.False(t, result.ParseWasSuccessful)
 		assert.Equal(t, "Algebraic Notation", result.NotationName)
@@ -99,7 +99,7 @@ func TestParseNotationDetailed_PartialParse(t *testing.T) {
 	})
 
 	t.Run("garbage input returns zero valid actions", func(t *testing.T) {
-		_, result, err := New().ParseNotationDetailed(InputGame{}, "hello world this is not chess")
+		_, result, err := New().ParseNotation(InputGame{}, "hello world this is not chess")
 		require.NoError(t, err)
 		assert.False(t, result.ParseWasSuccessful)
 		assert.Equal(t, 0, result.ValidActionCount)
@@ -110,7 +110,7 @@ func TestParseNotationDetailed_PartialParse(t *testing.T) {
 	t.Run("truncated ICCF game returns valid prefix", func(t *testing.T) {
 		// Third move 9999 is invalid ICCF
 		game := "1. 5254 5755\n2. 9999"
-		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		_, result, err := New().ParseNotation(InputGame{}, game)
 		require.NoError(t, err)
 		assert.False(t, result.ParseWasSuccessful)
 		assert.Equal(t, 2, result.ValidActionCount)
@@ -119,7 +119,7 @@ func TestParseNotationDetailed_PartialParse(t *testing.T) {
 
 	t.Run("descriptive game with invalid tail returns valid prefix and notation name", func(t *testing.T) {
 		game := "1. P-K4 P-K3\n2. P-Q4 P-Q9"
-		_, result, err := New().ParseNotationDetailed(InputGame{}, game)
+		_, result, err := New().ParseNotation(InputGame{}, game)
 		require.NoError(t, err)
 		assert.False(t, result.ParseWasSuccessful)
 		assert.Equal(t, "Descriptive Notation", result.NotationName)
@@ -127,38 +127,25 @@ func TestParseNotationDetailed_PartialParse(t *testing.T) {
 	})
 }
 
-func TestParseNotationDetailed_CustomInitialPosition(t *testing.T) {
+func TestParseNotation_CustomInitialPosition(t *testing.T) {
 	// Chernev Game 1 starting position
 	inputGame := InputGame{FENString: "8/8/8/8/8/1k5P/8/2K5 w - - 0 1"}
 	game := "1. P-R4 K-B5\n2. P-R5 K-Q4"
-	_, result, err := New().ParseNotationDetailed(inputGame, game)
+	_, result, err := New().ParseNotation(inputGame, game)
 	require.NoError(t, err)
 	assert.True(t, result.ParseWasSuccessful, "error: %v", result.Error)
 	assert.Equal(t, "Descriptive Notation", result.NotationName)
 	assert.Equal(t, 4, result.ValidActionCount)
 }
 
-func TestParseNotationDetailed_InvalidInputGame(t *testing.T) {
-	_, _, err := New().ParseNotationDetailed(InputGame{FENString: "not a fen"}, "1. e4")
+func TestParseNotation_InvalidInputGame(t *testing.T) {
+	_, _, err := New().ParseNotation(InputGame{FENString: "not a fen"}, "1. e4")
 	require.Error(t, err)
 }
 
-func TestParseNotation_BackwardsCompatible(t *testing.T) {
-	t.Run("successful parse returns steps and no error", func(t *testing.T) {
-		_, steps, err := New().ParseNotation(InputGame{}, "1. e4 e5\n2. Nf3")
-		require.NoError(t, err)
-		assert.Len(t, steps, 3)
-	})
-
-	t.Run("failed parse returns error", func(t *testing.T) {
-		_, _, err := New().ParseNotation(InputGame{}, "not a chess game at all")
-		require.Error(t, err)
-	})
-}
-
-func TestParseNotationDetailed_ActionStrings(t *testing.T) {
+func TestParseNotation_ActionStrings(t *testing.T) {
 	// The steps should carry the original action strings for frontend display
-	_, result, err := New().ParseNotationDetailed(InputGame{}, "1. e4 e5\n2. Nf3 Nc6")
+	_, result, err := New().ParseNotation(InputGame{}, "1. e4 e5\n2. Nf3 Nc6")
 	require.NoError(t, err)
 	require.Len(t, result.Steps, 4)
 	assert.Equal(t, "e4", result.Steps[0].ActionString)

--- a/handlers.go
+++ b/handlers.go
@@ -138,6 +138,50 @@ func handleCliParseNotation(flagParseNotation *string) {
 	fmt.Println(string(byts))
 }
 
+func handleServerParseNotationDetailed(w http.ResponseWriter, r *http.Request) {
+	type args struct {
+		Game           api.InputGame `json:"game"`
+		NotationString string        `json:"notationString"`
+	}
+	var input args
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	defer r.Body.Close()
+	outputGame, parseResult, err := a.ParseNotationDetailed(input.Game, input.NotationString)
+	if err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	type out struct {
+		Game        api.OutputGame        `json:"game"`
+		ParseResult api.OutputParseResult `json:"parseResult"`
+	}
+	json.NewEncoder(w).Encode(out{outputGame, parseResult})
+}
+
+func handleCliParseNotationDetailed(flagParseNotationDetailed *string) {
+	type args struct {
+		Game           api.InputGame `json:"game"`
+		NotationString string        `json:"notationString"`
+	}
+	var input args
+	if err := json.Unmarshal([]byte(*flagParseNotationDetailed), &input); err != nil {
+		mustCliFatal(err)
+	}
+	outputGame, parseResult, err := a.ParseNotationDetailed(input.Game, input.NotationString)
+	if err != nil {
+		mustCliFatal(err)
+	}
+	type out struct {
+		Game        api.OutputGame        `json:"game"`
+		ParseResult api.OutputParseResult `json:"parseResult"`
+	}
+	byts, _ := json.Marshal(out{outputGame, parseResult})
+	fmt.Println(string(byts))
+}
+
 func mustCliFatal(err error) {
 	fmt.Println(formatError(err))
 	os.Exit(1)

--- a/handlers.go
+++ b/handlers.go
@@ -105,51 +105,7 @@ func handleServerParseNotation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
-	outputGame, outputGameSteps, err := a.ParseNotation(input.Game, input.NotationString)
-	if err != nil {
-		fmt.Fprintln(w, formatError(err))
-		return
-	}
-	type out struct {
-		Game            api.OutputGame       `json:"game"`
-		OutputGameSteps []api.OutputGameStep `json:"outputGameSteps"`
-	}
-	json.NewEncoder(w).Encode(out{outputGame, outputGameSteps})
-}
-
-func handleCliParseNotation(flagParseNotation *string) {
-	type args struct {
-		Game           api.InputGame `json:"game"`
-		NotationString string        `json:"notationString"`
-	}
-	var input args
-	if err := json.Unmarshal([]byte(*flagParseNotation), &input); err != nil {
-		mustCliFatal(err)
-	}
-	outputGame, outputGameSteps, err := a.ParseNotation(input.Game, input.NotationString)
-	if err != nil {
-		mustCliFatal(err)
-	}
-	type out struct {
-		Game            api.OutputGame       `json:"game"`
-		OutputGameSteps []api.OutputGameStep `json:"outputGameSteps"`
-	}
-	byts, _ := json.Marshal(out{outputGame, outputGameSteps})
-	fmt.Println(string(byts))
-}
-
-func handleServerParseNotationDetailed(w http.ResponseWriter, r *http.Request) {
-	type args struct {
-		Game           api.InputGame `json:"game"`
-		NotationString string        `json:"notationString"`
-	}
-	var input args
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		fmt.Fprintln(w, formatError(err))
-		return
-	}
-	defer r.Body.Close()
-	outputGame, parseResult, err := a.ParseNotationDetailed(input.Game, input.NotationString)
+	outputGame, parseResult, err := a.ParseNotation(input.Game, input.NotationString)
 	if err != nil {
 		fmt.Fprintln(w, formatError(err))
 		return
@@ -161,16 +117,16 @@ func handleServerParseNotationDetailed(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(out{outputGame, parseResult})
 }
 
-func handleCliParseNotationDetailed(flagParseNotationDetailed *string) {
+func handleCliParseNotation(flagParseNotation *string) {
 	type args struct {
 		Game           api.InputGame `json:"game"`
 		NotationString string        `json:"notationString"`
 	}
 	var input args
-	if err := json.Unmarshal([]byte(*flagParseNotationDetailed), &input); err != nil {
+	if err := json.Unmarshal([]byte(*flagParseNotation), &input); err != nil {
 		mustCliFatal(err)
 	}
-	outputGame, parseResult, err := a.ParseNotationDetailed(input.Game, input.NotationString)
+	outputGame, parseResult, err := a.ParseNotation(input.Game, input.NotationString)
 	if err != nil {
 		mustCliFatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ var (
 	flagDefaultGame   = flag.Bool("defaultGame", false, "Default API call. Returns a default game.")
 	flagParseGame     = flag.String("parseGame", "", "ParseGame API call. Requires a JSON string with arguments. Please review spec.")
 	flagDoAction      = flag.String("doAction", "", "DoAction API call. Requires a JSON string with arguments. Please review spec.")
-	flagParseNotation = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
+	flagParseNotation         = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
+	flagParseNotationDetailed = flag.String("parseNotationDetailed", "", "ParseNotationDetailed API call. Requires a JSON string with arguments. Please review spec.")
 )
 
 func main() {
@@ -23,6 +24,7 @@ func main() {
 	http.HandleFunc("/defaultGame", handleServerDefaultGame)
 	http.HandleFunc("/doAction", handleServerDoAction)
 	http.HandleFunc("/parseNotation", handleServerParseNotation)
+	http.HandleFunc("/parseNotationDetailed", handleServerParseNotationDetailed)
 
 	switch {
 	case *flagServe != 0:
@@ -35,5 +37,7 @@ func main() {
 		handleCliDoAction(flagDoAction)
 	case *flagParseNotation != "":
 		handleCliParseNotation(flagParseNotation)
+	case *flagParseNotationDetailed != "":
+		handleCliParseNotationDetailed(flagParseNotationDetailed)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,8 +13,7 @@ var (
 	flagDefaultGame   = flag.Bool("defaultGame", false, "Default API call. Returns a default game.")
 	flagParseGame     = flag.String("parseGame", "", "ParseGame API call. Requires a JSON string with arguments. Please review spec.")
 	flagDoAction      = flag.String("doAction", "", "DoAction API call. Requires a JSON string with arguments. Please review spec.")
-	flagParseNotation         = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
-	flagParseNotationDetailed = flag.String("parseNotationDetailed", "", "ParseNotationDetailed API call. Requires a JSON string with arguments. Please review spec.")
+	flagParseNotation = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
 )
 
 func main() {
@@ -24,7 +23,6 @@ func main() {
 	http.HandleFunc("/defaultGame", handleServerDefaultGame)
 	http.HandleFunc("/doAction", handleServerDoAction)
 	http.HandleFunc("/parseNotation", handleServerParseNotation)
-	http.HandleFunc("/parseNotationDetailed", handleServerParseNotationDetailed)
 
 	switch {
 	case *flagServe != 0:
@@ -37,7 +35,5 @@ func main() {
 		handleCliDoAction(flagDoAction)
 	case *flagParseNotation != "":
 		handleCliParseNotation(flagParseNotation)
-	case *flagParseNotationDetailed != "":
-		handleCliParseNotationDetailed(flagParseNotationDetailed)
 	}
 }

--- a/main_js.go
+++ b/main_js.go
@@ -32,16 +32,7 @@ func DoAction(this js.Value, p []js.Value) interface{} {
 }
 
 func ParseNotation(this js.Value, p []js.Value) interface{} {
-	og, ogs, err := a.ParseNotation(convertToInputGame(p[0]), p[1].String())
-	return js.ValueOf(map[string]interface{}{
-		"outputGame":      convertOutputGame(og),
-		"outputGameSteps": convertOutputGameSteps(ogs),
-		"error":           convertError(err),
-	})
-}
-
-func ParseNotationDetailed(this js.Value, p []js.Value) interface{} {
-	og, result, err := a.ParseNotationDetailed(convertToInputGame(p[0]), p[1].String())
+	og, result, err := a.ParseNotation(convertToInputGame(p[0]), p[1].String())
 	return js.ValueOf(map[string]interface{}{
 		"outputGame":  convertOutputGame(og),
 		"parseResult": convertOutputParseResult(result),
@@ -64,7 +55,6 @@ func main() {
 	js.Global().Set("ParseGame", js.FuncOf(ParseGame))
 	js.Global().Set("DoAction", js.FuncOf(DoAction))
 	js.Global().Set("ParseNotation", js.FuncOf(ParseNotation))
-	js.Global().Set("ParseNotationDetailed", js.FuncOf(ParseNotationDetailed))
 	select {}
 }
 

--- a/main_js.go
+++ b/main_js.go
@@ -40,11 +40,31 @@ func ParseNotation(this js.Value, p []js.Value) interface{} {
 	})
 }
 
+func ParseNotationDetailed(this js.Value, p []js.Value) interface{} {
+	og, result, err := a.ParseNotationDetailed(convertToInputGame(p[0]), p[1].String())
+	return js.ValueOf(map[string]interface{}{
+		"outputGame":  convertOutputGame(og),
+		"parseResult": convertOutputParseResult(result),
+		"error":       convertError(err),
+	})
+}
+
+func convertOutputParseResult(r api.OutputParseResult) map[string]interface{} {
+	return map[string]interface{}{
+		"notationName":       r.NotationName,
+		"parseWasSuccessful": r.ParseWasSuccessful,
+		"validActionCount":   r.ValidActionCount,
+		"steps":              convertOutputGameSteps(r.Steps),
+		"error":              r.Error,
+	}
+}
+
 func main() {
 	js.Global().Set("DefaultGame", js.FuncOf(DefaultGame))
 	js.Global().Set("ParseGame", js.FuncOf(ParseGame))
 	js.Global().Set("DoAction", js.FuncOf(DoAction))
 	js.Global().Set("ParseNotation", js.FuncOf(ParseNotation))
+	js.Global().Set("ParseNotationDetailed", js.FuncOf(ParseNotationDetailed))
 	select {}
 }
 


### PR DESCRIPTION
Adds ParseNotationDetailed which tries all six supported notations, picks the one that parses furthest, and returns partial results (valid prefix + most-likely notation name + error) on failure. Exposed via HTTP, CLI, and wasm. Fixes #17.