### PR TITLE
Implement ConvertNotation: convert games between notations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ DefaultGame() OutputGame
 ParseGame(game InputGame) (OutputGame, error)
 DoAction(game InputGame, action InputAction) (OutputGame, OutputAction, error)
 
-// Currently only supporting Algebraic Notation; others coming soon
-ParseNotation(game InputGame, notationString string) (OutputGame, []OutputGameStep, error)
+// Auto-detects the notation: Algebraic (incl. figurine and PGN), Coordinate, Descriptive, ICCF, Smith
+ParseNotation(game InputGame, notationString string) (OutputGame, OutputParseResult, error)
 
-// Coming soon
-ConvertNotation(game InputGame, notationString string, toNotation string) (OutputGame, []OutputGameStep, error)
+// Auto-detects the source notation and re-renders every move in the target notation:
+// one of {Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith}
+ConvertNotation(game InputGame, notationString string, targetNotation string) (OutputGame, OutputParseResult, error)
 ```
 
 ## Server example

--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/marianogappa/cheesse/core"
 	"github.com/marianogappa/cheesse/parser"
@@ -98,7 +99,16 @@ func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, O
 	if err != nil {
 		return OutputGame{}, OutputParseResult{}, err
 	}
+	gameSteps, result := parseNotationAutoDetect(parsedGame, notationString)
+	result.Steps = mapGameStepsToOutputGameSteps(gameSteps)
+	return mapGameToOutputGame(parsedGame), result, nil
+}
 
+// parseNotationAutoDetect tries all supported notation parsers and returns the game
+// steps of the attempt that parsed the furthest, along with a parse result describing
+// the winning attempt (with Steps unset; callers map the steps as needed).
+func parseNotationAutoDetect(parsedGame core.Game, notationString string) ([]core.GameStep, OutputParseResult) {
+	notationString = strings.TrimSpace(notationString)
 	type notationCandidate struct {
 		name  string
 		parse func() ([]core.GameStep, error)
@@ -128,7 +138,10 @@ func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, O
 		}},
 	}
 
-	var best *OutputParseResult
+	var (
+		bestSteps  []core.GameStep
+		bestResult *OutputParseResult
+	)
 	for _, candidate := range candidates {
 		gameSteps, err := candidate.parse()
 		validSteps := len(gameSteps)
@@ -136,7 +149,6 @@ func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, O
 			NotationName:       candidate.name,
 			ParseWasSuccessful: err == nil,
 			ValidActionCount:   validSteps,
-			Steps:              mapGameStepsToOutputGameSteps(gameSteps),
 		}
 		if err != nil {
 			result.Error = err.Error()
@@ -144,13 +156,79 @@ func (a API) ParseNotation(game InputGame, notationString string) (OutputGame, O
 
 		// A fully-successful parse with at least one step wins immediately.
 		if result.ParseWasSuccessful && validSteps > 0 {
-			return mapGameToOutputGame(parsedGame), result, nil
+			return gameSteps, result
 		}
 		// Otherwise keep the attempt that parsed the furthest.
-		if best == nil || validSteps > best.ValidActionCount {
-			best = &result
+		if bestResult == nil || validSteps > bestResult.ValidActionCount {
+			bestSteps, bestResult = gameSteps, &result
 		}
 	}
 
-	return mapGameToOutputGame(parsedGame), *best, nil
+	return bestSteps, *bestResult
+}
+
+// ConvertNotation takes any valid input game and a string representing a match in
+// some notation, auto-detects the source notation, and re-renders every move in the
+// target notation.
+//
+// `targetNotation` must be one of: `{Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith}`
+// (case-insensitive).
+//
+// Partial input still converts the valid prefix: the result reports the detected
+// source notation, whether the whole input parsed, how many actions were valid, and
+// one OutputGameStep per valid action whose `actionString` is rendered in the target
+// notation.
+//
+// An error is only returned if the input game itself is invalid or the target
+// notation is unknown.
+//
+// Please refer to InputGame's, OutputGame's, OutputGameStep's and OutputParseResult's
+// docs for format details.
+func (a API) ConvertNotation(game InputGame, notationString string, targetNotation string) (OutputGame, OutputParseResult, error) {
+	parsedGame, err := a.parseGame(game)
+	if err != nil {
+		return OutputGame{}, OutputParseResult{}, err
+	}
+
+	targetPrinter, targetCharacteristics, err := notationPrinter(targetNotation)
+	if err != nil {
+		return OutputGame{}, OutputParseResult{}, err
+	}
+
+	gameSteps, result := parseNotationAutoDetect(parsedGame, notationString)
+
+	result.Steps = mapGameStepsToOutputGameSteps(gameSteps)
+	for i, gameStep := range gameSteps {
+		if gameStep.StepAction == (core.Action{}) {
+			// Result markers (e.g. "1-0" in PGN) have no action to re-render.
+			continue
+		}
+		actionString, err := targetPrinter.PrintAction(gameStep, targetCharacteristics)
+		if err != nil {
+			return OutputGame{}, OutputParseResult{}, err
+		}
+		result.Steps[i].ActionString = actionString
+	}
+
+	return mapGameToOutputGame(parsedGame), result, nil
+}
+
+var errUnknownTargetNotation = errors.New("unknown target notation: please use one of {Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith}")
+
+func notationPrinter(targetNotation string) (printer.NotationPrinter, printer.GameCharacteristics, error) {
+	switch strings.ToLower(targetNotation) {
+	case "algebraic":
+		return printer.AlgebraicPrinter{}, printer.SANCharacteristics(), nil
+	case "figurine":
+		return printer.AlgebraicPrinter{}, printer.FigurineCharacteristics(), nil
+	case "descriptive":
+		return printer.DescriptivePrinter{}, printer.GameCharacteristics{}, nil
+	case "coordinate":
+		return printer.CoordinatePrinter{}, printer.SANCharacteristics(), nil
+	case "iccf":
+		return printer.ICCFPrinter{}, printer.GameCharacteristics{}, nil
+	case "smith":
+		return printer.SmithPrinter{}, printer.GameCharacteristics{}, nil
+	}
+	return nil, printer.GameCharacteristics{}, errUnknownTargetNotation
 }

--- a/api/convert_notation_test.go
+++ b/api/convert_notation_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actionStrings extracts the per-step action strings of a conversion result.
+func actionStrings(result OutputParseResult) []string {
+	out := make([]string, len(result.Steps))
+	for i, step := range result.Steps {
+		out[i] = step.ActionString
+	}
+	return out
+}
+
+// The six-notation-suite French Defense expressed as the expected per-move action
+// strings in each target notation. Cross-converting between any source notation in
+// sixNotationGames (parse_notation_test.go) and any of these targets must yield
+// exactly these strings.
+var expectedConversionsByTarget = map[string][]string{
+	"Algebraic": {
+		"e4", "e6", "d4", "d5", "Nc3", "Bb4", "Bb5+", "Bd7", "Bxd7+", "Qxd7", "Ne2", "dxe4", "O-O",
+	},
+	"Figurine": {
+		"e4", "e6", "d4", "d5", "♘c3", "♝b4", "♗b5+", "♝d7", "♗xd7+", "♛xd7", "♘e2", "dxe4", "O-O",
+	},
+	"Coordinate": {
+		"e2-e4", "e7-e6", "d2-d4", "d7-d5", "b1-c3", "f8-b4", "f1-b5+", "c8-d7", "b5xd7+", "d8xd7", "g1-e2", "d5xe4", "O-O",
+	},
+	"ICCF": {
+		"5254", "5756", "4244", "4745", "2133", "6824", "6125", "3847", "2547", "4847", "7152", "4554", "5171",
+	},
+	"Smith": {
+		"e2e4", "e7e6", "d2d4", "d7d5", "b1c3", "f8b4", "f1b5", "c8d7", "b5d7b", "d8d7b", "g1e2", "d5e4p", "e1g1c",
+	},
+}
+
+func TestConvertNotation_CrossNotationMatrix(t *testing.T) {
+	// Every source notation from the six-notation suite converted to every target
+	// notation must produce the exact expected action strings.
+	for _, source := range sixNotationGames {
+		for target, expected := range expectedConversionsByTarget {
+			t.Run(source.notationName+"->"+target, func(t *testing.T) {
+				_, result, err := New().ConvertNotation(InputGame{}, source.game, target)
+				require.NoError(t, err)
+				require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+				assert.Equal(t, source.notationName, result.NotationName)
+
+				actual := actionStrings(result)
+				// PGN sources have a trailing result-marker step with no action;
+				// compare only the action-bearing steps.
+				if len(actual) == len(expected)+1 && actual[len(actual)-1] == "" {
+					actual = actual[:len(actual)-1]
+				}
+				assert.Equal(t, expected, actual)
+			})
+		}
+	}
+}
+
+func TestConvertNotation_ToDescriptive(t *testing.T) {
+	// Descriptive output isn't asserted in the cross matrix because its rendering
+	// varies more; assert the exact strings once from an algebraic source.
+	algebraic := `1. e4 e6
+2. d4 d5
+3. Nc3 Bb4
+4. Bb5+ Bd7
+5. Bxd7+ Qxd7
+6. Ne2 dxe4
+7. 0-0`
+	_, result, err := New().ConvertNotation(InputGame{}, algebraic, "Descriptive")
+	require.NoError(t, err)
+	require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+	got := actionStrings(result)
+	require.Len(t, got, 13)
+	assert.Equal(t, "P-K4", got[0])
+	assert.Equal(t, "P-K3", got[1])
+	assert.Equal(t, "P-Q4", got[2])
+	assert.Equal(t, "N-QB3", got[4])
+	assert.Equal(t, "0-0", got[12])
+}
+
+func TestConvertNotation_PartialInput(t *testing.T) {
+	// Invalid move mid-game: valid prefix still converts.
+	game := "1. e4 e5\n2. Bc4 Nc6\n3. Qh7 Nf6"
+	_, result, err := New().ConvertNotation(InputGame{}, game, "ICCF")
+	require.NoError(t, err)
+	assert.False(t, result.ParseWasSuccessful)
+	assert.Equal(t, "Algebraic Notation", result.NotationName)
+	assert.Equal(t, 4, result.ValidActionCount)
+	assert.Equal(t, []string{"5254", "5755", "6134", "2836"}, actionStrings(result))
+	assert.NotEmpty(t, result.Error)
+}
+
+func TestConvertNotation_CustomInitialPosition(t *testing.T) {
+	// Chernev Game 1: descriptive source from custom FEN converted to algebraic.
+	inputGame := InputGame{FENString: "8/8/8/8/8/1k5P/8/2K5 w - - 0 1"}
+	game := "1. P-R4 K-B5\n2. P-R5 K-Q4\n3. P-R6 K-K3\n4. P-R7 K-B2\n5. P-R8(Q) Resigns"
+	_, result, err := New().ConvertNotation(inputGame, game, "Algebraic")
+	require.NoError(t, err)
+	require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+	got := actionStrings(result)
+	require.Len(t, got, 10)
+	assert.Equal(t, []string{"h4", "Kc4", "h5", "Kd5", "h6", "Ke6", "h7", "Kf7", "h8=Q", "resigns"}, got)
+}
+
+func TestConvertNotation_UnknownTargetNotation(t *testing.T) {
+	_, _, err := New().ConvertNotation(InputGame{}, "1. e4", "Klingon")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown target notation")
+}
+
+func TestConvertNotation_TargetNotationCaseInsensitive(t *testing.T) {
+	for _, target := range []string{"algebraic", "ALGEBRAIC", "Algebraic", "iccf", "ICCF", "smith", "figurine", "coordinate", "descriptive"} {
+		_, result, err := New().ConvertNotation(InputGame{}, "1. e4 e5", target)
+		require.NoError(t, err, "target %q should be accepted", target)
+		assert.True(t, result.ParseWasSuccessful)
+	}
+}
+
+func TestConvertNotation_InvalidInputGame(t *testing.T) {
+	_, _, err := New().ConvertNotation(InputGame{FENString: "not a fen"}, "1. e4", "Algebraic")
+	require.Error(t, err)
+}
+
+func TestConvertNotation_GarbageInput(t *testing.T) {
+	_, result, err := New().ConvertNotation(InputGame{}, "hello world not chess", "Algebraic")
+	require.NoError(t, err)
+	assert.False(t, result.ParseWasSuccessful)
+	assert.Equal(t, 0, result.ValidActionCount)
+	assert.Empty(t, result.Steps)
+}
+
+func TestConvertNotation_RoundTripThroughAllNotations(t *testing.T) {
+	// Convert algebraic → target, then feed the converted text back (joined as one
+	// half-move per line pair) and convert to algebraic; the result must match the
+	// canonical algebraic strings. This exercises print→parse consistency per notation.
+	canonical := []string{"e4", "e6", "d4", "d5", "Nc3", "Bb4", "Bb5+", "Bd7", "Bxd7+", "Qxd7", "Ne2", "dxe4", "O-O"}
+	algebraic := `1. e4 e6
+2. d4 d5
+3. Nc3 Bb4
+4. Bb5+ Bd7
+5. Bxd7+ Qxd7
+6. Ne2 dxe4
+7. 0-0`
+
+	for _, target := range []string{"Algebraic", "ICCF", "Smith", "Coordinate", "Figurine"} {
+		t.Run(target, func(t *testing.T) {
+			_, converted, err := New().ConvertNotation(InputGame{}, algebraic, target)
+			require.NoError(t, err)
+			require.True(t, converted.ParseWasSuccessful)
+
+			// Reassemble the converted action strings into a game text with move
+			// numbers (numberless ICCF is ambiguous: a bare "5254" reads as a move
+			// number).
+			var sb strings.Builder
+			for i := 0; i < len(converted.Steps); i += 2 {
+				fmt.Fprintf(&sb, "%d. %s", i/2+1, converted.Steps[i].ActionString)
+				if i+1 < len(converted.Steps) {
+					sb.WriteString(" ")
+					sb.WriteString(converted.Steps[i+1].ActionString)
+				}
+				sb.WriteString("\n")
+			}
+
+			_, back, err := New().ConvertNotation(InputGame{}, sb.String(), "Algebraic")
+			require.NoError(t, err)
+			require.True(t, back.ParseWasSuccessful, "re-parse of %s output failed: %v\ninput:\n%s", target, back.Error, sb.String())
+			assert.Equal(t, canonical, actionStrings(back))
+		})
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -138,6 +138,52 @@ func handleCliParseNotation(flagParseNotation *string) {
 	fmt.Println(string(byts))
 }
 
+func handleServerConvertNotation(w http.ResponseWriter, r *http.Request) {
+	type args struct {
+		Game           api.InputGame `json:"game"`
+		NotationString string        `json:"notationString"`
+		TargetNotation string        `json:"targetNotation"`
+	}
+	var input args
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	defer r.Body.Close()
+	outputGame, parseResult, err := a.ConvertNotation(input.Game, input.NotationString, input.TargetNotation)
+	if err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	type out struct {
+		Game        api.OutputGame        `json:"game"`
+		ParseResult api.OutputParseResult `json:"parseResult"`
+	}
+	json.NewEncoder(w).Encode(out{outputGame, parseResult})
+}
+
+func handleCliConvertNotation(flagConvertNotation *string) {
+	type args struct {
+		Game           api.InputGame `json:"game"`
+		NotationString string        `json:"notationString"`
+		TargetNotation string        `json:"targetNotation"`
+	}
+	var input args
+	if err := json.Unmarshal([]byte(*flagConvertNotation), &input); err != nil {
+		mustCliFatal(err)
+	}
+	outputGame, parseResult, err := a.ConvertNotation(input.Game, input.NotationString, input.TargetNotation)
+	if err != nil {
+		mustCliFatal(err)
+	}
+	type out struct {
+		Game        api.OutputGame        `json:"game"`
+		ParseResult api.OutputParseResult `json:"parseResult"`
+	}
+	byts, _ := json.Marshal(out{outputGame, parseResult})
+	fmt.Println(string(byts))
+}
+
 func mustCliFatal(err error) {
 	fmt.Println(formatError(err))
 	os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ var (
 	flagDefaultGame   = flag.Bool("defaultGame", false, "Default API call. Returns a default game.")
 	flagParseGame     = flag.String("parseGame", "", "ParseGame API call. Requires a JSON string with arguments. Please review spec.")
 	flagDoAction      = flag.String("doAction", "", "DoAction API call. Requires a JSON string with arguments. Please review spec.")
-	flagParseNotation = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
+	flagParseNotation   = flag.String("parseNotation", "", "ParseNotation API call. Requires a JSON string with arguments. Please review spec.")
+	flagConvertNotation = flag.String("convertNotation", "", "ConvertNotation API call. Requires a JSON string with arguments. Please review spec.")
 )
 
 func main() {
@@ -23,6 +24,7 @@ func main() {
 	http.HandleFunc("/defaultGame", handleServerDefaultGame)
 	http.HandleFunc("/doAction", handleServerDoAction)
 	http.HandleFunc("/parseNotation", handleServerParseNotation)
+	http.HandleFunc("/convertNotation", handleServerConvertNotation)
 
 	switch {
 	case *flagServe != 0:
@@ -35,5 +37,7 @@ func main() {
 		handleCliDoAction(flagDoAction)
 	case *flagParseNotation != "":
 		handleCliParseNotation(flagParseNotation)
+	case *flagConvertNotation != "":
+		handleCliConvertNotation(flagConvertNotation)
 	}
 }

--- a/main_js.go
+++ b/main_js.go
@@ -50,11 +50,21 @@ func convertOutputParseResult(r api.OutputParseResult) map[string]interface{} {
 	}
 }
 
+func ConvertNotation(this js.Value, p []js.Value) interface{} {
+	og, result, err := a.ConvertNotation(convertToInputGame(p[0]), p[1].String(), p[2].String())
+	return js.ValueOf(map[string]interface{}{
+		"outputGame":  convertOutputGame(og),
+		"parseResult": convertOutputParseResult(result),
+		"error":       convertError(err),
+	})
+}
+
 func main() {
 	js.Global().Set("DefaultGame", js.FuncOf(DefaultGame))
 	js.Global().Set("ParseGame", js.FuncOf(ParseGame))
 	js.Global().Set("DoAction", js.FuncOf(DoAction))
 	js.Global().Set("ParseNotation", js.FuncOf(ParseNotation))
+	js.Global().Set("ConvertNotation", js.FuncOf(ConvertNotation))
 	select {}
 }
 


### PR DESCRIPTION
Adds ConvertNotation which auto-detects the source notation and re-renders every move in a target notation (Algebraic/Figurine/Descriptive/Coordinate/ICCF/Smith), with partial-input support. Validated by a full cross-notation conversion matrix and print-parse round-trips. Fixes #16.