### PR TITLE
Fix ASCII result markers (1-0) never matching in the algebraic parser

### DIFF
--- a/parser/end_of_game_test.go
+++ b/parser/end_of_game_test.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlgebraicParserResultMarkers(t *testing.T) {
+	testCases := []struct {
+		name   string
+		marker string
+	}{
+		{"ASCII 1-0", "1-0"},
+		{"en-dash 1–0", "1–0"},
+		{"ASCII 0-1", "0-1"},
+		{"en-dash 0–1", "0–1"},
+		{"ASCII ½-½", "½-½"},
+		{"en-dash ½–½", "½–½"},
+		{"ASCII 1/2-1/2", "1/2-1/2"},
+		{"en-dash 1/2–1/2", "1/2–1/2"},
+		{"resigns", "resigns"},
+		{"Resigns", "Resigns"},
+		{"White resigns", "White resigns"},
+		{"Black resigns", "Black resigns"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			game := "1. e4 e5\n2. " + tc.marker
+			steps, err := NewNotationParserAlgebraic(Characteristics{}).Parse(core.NewDefaultGame(), game)
+			require.NoError(t, err, "result marker %q should parse", tc.marker)
+			require.Len(t, steps, 3)
+			assert.True(t, steps[2].StepAction.IsResign, "last step should be the terminal action")
+		})
+	}
+}
+
+func TestDescriptiveParserResultMarkers(t *testing.T) {
+	testCases := []struct {
+		name   string
+		marker string
+	}{
+		{"ASCII 1-0", "1-0"},
+		{"en-dash 1–0", "1–0"},
+		{"ASCII ½-½", "½-½"},
+		{"Resigns", "Resigns"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			game := "1. P-K4 P-K4\n2. " + tc.marker
+			steps, err := NewNotationParserDescriptive(Characteristics{}).Parse(core.NewDefaultGame(), game)
+			require.NoError(t, err, "result marker %q should parse", tc.marker)
+			require.Len(t, steps, 3)
+			assert.True(t, steps[2].StepAction.IsResign, "last step should be the terminal action")
+		})
+	}
+}

--- a/parser/notation_algebraic.go
+++ b/parser/notation_algebraic.go
@@ -207,32 +207,7 @@ func NewNotationParserAlgebraic(initialCharacteristics Characteristics) *Notatio
 				},
 
 				// End of game
-				`(1–0|0–1|½–½|resigns|White resigns|Black resigns)`: func(ms []string, g core.Game) []tokenMatch {
-					var usesEndGameSymbol string
-					switch ms[1] {
-					case "1-0", "0-1", "½–½":
-						usesEndGameSymbol = "numbers"
-					case "resigns":
-						usesEndGameSymbol = "resigns"
-					case "White resigns", "Black resigns":
-						usesEndGameSymbol = "color resigns"
-					}
-					ap := actionPattern{
-						isResign:           pBool(strings.HasSuffix(usesEndGameSymbol, "resigns")),
-						isPromotion:        pBool(false),
-						isCastle:           pBool(false),
-						isCapture:          pBool(false),
-						isEnPassantCapture: pBool(false),
-					}
-					ch := Characteristics{usesEndGameSymbol: &usesEndGameSymbol}
-					if ch.isCheck {
-						ap.isCheck = pBool(true)
-					}
-					if ch.isCheckmate {
-						ap.isCheckmate = pBool(true)
-					}
-					return []tokenMatch{{ms[0], &ap, ch}}
-				},
+				rxEndOfGame: processEndOfGameToken,
 			},
 		}
 
@@ -307,6 +282,38 @@ func NewNotationParserAlgebraic(initialCharacteristics Characteristics) *Notatio
 	)
 
 	return newNotationParser(transitions, evolveCharacteristics, initialCharacteristics)
+}
+
+// rxEndOfGame accepts result markers with both ASCII hyphens and en-dashes, plus the
+// ½-½ and 1/2-1/2 draw spellings and resign words. Shared by the algebraic and
+// descriptive parsers.
+const rxEndOfGame = `(1[–-]0|0[–-]1|½[–-]½|1/2[–-]1/2|White resigns|Black resigns|resigns|Resigns)`
+
+// processEndOfGameToken interprets an end-of-game token (see rxEndOfGame).
+func processEndOfGameToken(ms []string, g core.Game) []tokenMatch {
+	normalized := strings.ReplaceAll(ms[1], "–", "-")
+	var usesEndGameSymbol string
+	switch normalized {
+	case "1-0", "0-1", "½-½", "1/2-1/2":
+		usesEndGameSymbol = "numbers"
+	case "resigns":
+		usesEndGameSymbol = "resigns"
+	case "Resigns":
+		usesEndGameSymbol = "Resigns"
+	case "White resigns", "Black resigns":
+		usesEndGameSymbol = "color resigns"
+	}
+	// The engine's only terminal action is resignation, so every end-of-game
+	// marker matches the resign action.
+	ap := actionPattern{
+		isResign:           pBool(true),
+		isPromotion:        pBool(false),
+		isCastle:           pBool(false),
+		isCapture:          pBool(false),
+		isEnPassantCapture: pBool(false),
+	}
+	ch := Characteristics{usesEndGameSymbol: &usesEndGameSymbol}
+	return []tokenMatch{{ms[0], &ap, ch}}
 }
 
 func stringToPieceType(s string) core.PieceType {

--- a/parser/notation_descriptive.go
+++ b/parser/notation_descriptive.go
@@ -244,34 +244,7 @@ func NewNotationParserDescriptive(initialCharacteristics Characteristics) *Notat
 				},
 
 				// End of game
-				`(1–0|0–1|½–½|resigns|White resigns|Black resigns|Resigns)`: func(ms []string, g core.Game) []tokenMatch {
-					var usesEndGameSymbol string
-					switch ms[1] {
-					case "1-0", "0-1", "½–½":
-						usesEndGameSymbol = "numbers"
-					case "resigns":
-						usesEndGameSymbol = "resigns"
-					case "Resigns":
-						usesEndGameSymbol = "Resigns"
-					case "White resigns", "Black resigns":
-						usesEndGameSymbol = "color resigns"
-					}
-					ap := actionPattern{
-						isResign:           pBool(true),
-						isPromotion:        pBool(false),
-						isCastle:           pBool(false),
-						isCapture:          pBool(false),
-						isEnPassantCapture: pBool(false),
-					}
-					ch := Characteristics{usesEndGameSymbol: &usesEndGameSymbol}
-					if ch.isCheck {
-						ap.isCheck = pBool(true)
-					}
-					if ch.isCheckmate {
-						ap.isCheckmate = pBool(true)
-					}
-					return []tokenMatch{{ms[0], &ap, ch}}
-				},
+				rxEndOfGame: processEndOfGameToken,
 			},
 		}
 


### PR DESCRIPTION
The end-of-game regex matched en-dashes while the switch compared ASCII hyphens, so plain 1-0/0-1 never matched. Both dash forms are now accepted via a shared rxEndOfGame regex + handler unified across the algebraic and descriptive parsers. Fixes #29.