### PR TITLE
Add AI move selection: random and basic minimax

### DIFF
--- a/ai/ai.go
+++ b/ai/ai.go
@@ -1,0 +1,199 @@
+package ai
+
+import (
+	"math"
+	"math/rand"
+
+	"github.com/marianogappa/cheesse/core"
+)
+
+// RandomAction picks a uniformly random legal non-resign action for the side to
+// move. Returns the action and the resulting game, or (Action{}, game, false)
+// when the game is already over.
+func RandomAction(g core.Game, rng *rand.Rand) (core.Action, core.Game, bool) {
+	nonResign := nonResignActions(g)
+	if len(nonResign) == 0 {
+		return core.Action{}, g, false
+	}
+	action := nonResign[rng.Intn(len(nonResign))]
+	return action, g.DoAction(action), true
+}
+
+// BasicAIAction selects the best action for the side to move using minimax with
+// alpha-beta pruning at the given depth. Depth 0 evaluates the position after
+// each candidate move; depth 1 looks one full move (two plies) ahead; etc.
+// Returns the action, resulting game, and true; or (Action{}, game, false) when
+// the game is already over.
+func BasicAIAction(g core.Game, depth int) (core.Action, core.Game, bool) {
+	nonResign := nonResignActions(g)
+	if len(nonResign) == 0 {
+		return core.Action{}, g, false
+	}
+
+	player := int(g.Turn())
+	bestScore := math.MinInt64
+	bestIdx := 0
+
+	for i, action := range nonResign {
+		newGame := g.DoAction(action)
+		score := alphabeta(newGame, action, player, depth, math.MinInt64, math.MaxInt64)
+		if score > bestScore || (score == bestScore && tieBreakPrefer(action, nonResign[bestIdx])) {
+			bestScore = score
+			bestIdx = i
+		}
+	}
+
+	chosen := nonResign[bestIdx]
+	return chosen, g.DoAction(chosen), true
+}
+
+func nonResignActions(g core.Game) []core.Action {
+	out := make([]core.Action, 0, len(g.Actions))
+	for _, a := range g.Actions {
+		if !a.IsResign {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func alphabeta(g core.Game, lastAction core.Action, player int, depth int, alpha, beta int) int {
+	if depth == 0 {
+		return evaluate(g, lastAction, player)
+	}
+
+	nonResign := nonResignActions(g)
+	if len(nonResign) == 0 {
+		return evaluate(g, lastAction, player)
+	}
+
+	if int(g.Turn()) != player {
+		// Maximizing (our turn next is opponent's perspective → we maximize our score)
+		v := math.MinInt64
+		for _, action := range nonResign {
+			newGame := g.DoAction(action)
+			score := alphabeta(newGame, action, player, depth-1, alpha, beta)
+			if score > v {
+				v = score
+			}
+			if v > alpha {
+				alpha = v
+			}
+			if beta <= alpha {
+				break
+			}
+		}
+		return v
+	}
+
+	// Minimizing (opponent's turn)
+	v := math.MaxInt64
+	for _, action := range nonResign {
+		newGame := g.DoAction(action)
+		score := alphabeta(newGame, action, player, depth-1, alpha, beta)
+		if score < v {
+			v = score
+		}
+		if v < beta {
+			beta = v
+		}
+		if beta <= alpha {
+			break
+		}
+	}
+	return v
+}
+
+func sign(owner, player int) int {
+	if owner == player {
+		return 1
+	}
+	return -1
+}
+
+func materialValue(pt core.PieceType) int {
+	switch pt {
+	case core.PieceQueen:
+		return 9
+	case core.PieceRook:
+		return 5
+	case core.PieceBishop, core.PieceKnight:
+		return 3
+	case core.PiecePawn:
+		return 1
+	}
+	return 0
+}
+
+func evaluate(g core.Game, lastAction core.Action, player int) int {
+	actionTurn := int(lastAction.FromPiece.Owner)
+	opponent := 1 - player
+
+	// Checkmate is decisive
+	if g.IsCheckmate {
+		return math.MaxInt64 / 2 * sign(actionTurn, player)
+	}
+	if g.IsStalemate || g.IsDraw {
+		return 0
+	}
+
+	// Material
+	playerMaterial, opponentMaterial := 0, 0
+	for _, piece := range g.Pieces[player] {
+		playerMaterial += materialValue(piece.PieceType)
+	}
+	for _, piece := range g.Pieces[opponent] {
+		opponentMaterial += materialValue(piece.PieceType)
+	}
+	totalMaterial := (playerMaterial - opponentMaterial) * 1_000_000_000
+
+	// Check bonus
+	checkBonus := 0
+	if g.IsCheck {
+		checkBonus = 100_000_000 * sign(actionTurn, player)
+	}
+
+	// Center control: pieces in the center (files c-f, ranks 4-5)
+	centerPlayer, centerOpponent := 0, 0
+	for _, piece := range g.Pieces[player] {
+		if piece.XY.X >= 2 && piece.XY.X <= 5 && piece.XY.Y >= 3 && piece.XY.Y <= 4 {
+			centerPlayer++
+		}
+	}
+	for _, piece := range g.Pieces[opponent] {
+		if piece.XY.X >= 2 && piece.XY.X <= 5 && piece.XY.Y >= 3 && piece.XY.Y <= 4 {
+			centerOpponent++
+		}
+	}
+	centerBonus := (centerPlayer - centerOpponent) * 100
+
+	// Castling incentive
+	castleBonus := 0
+	if lastAction.IsCastle {
+		castleBonus = 100 * sign(actionTurn, player)
+	}
+
+	return totalMaterial + checkBonus + centerBonus + castleBonus
+}
+
+// tieBreakPrefer returns true if a should be preferred over b when scores are equal.
+func tieBreakPrefer(a, b core.Action) bool {
+	return actionPriority(a) > actionPriority(b)
+}
+
+func actionPriority(a core.Action) int {
+	switch {
+	case a.IsPromotion && a.IsCapture:
+		return 6
+	case a.IsPromotion:
+		return 5
+	case a.IsCapture:
+		return 4
+	case a.IsEnPassantCapture:
+		return 3
+	case a.IsCastle:
+		return 2
+	default:
+		return 1
+	}
+}

--- a/ai/ai_test.go
+++ b/ai/ai_test.go
@@ -1,0 +1,106 @@
+package ai
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomAction_ReturnsLegalAction(t *testing.T) {
+	g := core.NewDefaultGame()
+	rng := rand.New(rand.NewSource(42))
+	action, newGame, ok := RandomAction(g, rng)
+	require.True(t, ok)
+	assert.NotEqual(t, core.Action{}, action)
+	assert.False(t, action.IsResign)
+	assert.NotEqual(t, g.ToFEN(), newGame.ToFEN())
+}
+
+func TestRandomAction_SeededDeterminism(t *testing.T) {
+	g := core.NewDefaultGame()
+	rng1 := rand.New(rand.NewSource(123))
+	rng2 := rand.New(rand.NewSource(123))
+	a1, _, _ := RandomAction(g, rng1)
+	a2, _, _ := RandomAction(g, rng2)
+	assert.Equal(t, a1, a2)
+}
+
+func TestRandomAction_GameOver(t *testing.T) {
+	// Scholar's mate final position: Qf7# Black is checkmated.
+	g, err := core.NewGameFromFEN("r1bqkb1r/pppp1Qpp/2n2n2/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4")
+	require.NoError(t, err)
+	require.True(t, g.IsGameOver, "position should be game over (checkmate)")
+	_, _, ok := RandomAction(g, rand.New(rand.NewSource(0)))
+	assert.False(t, ok)
+}
+
+func TestBasicAI_ChoosesCheckmate(t *testing.T) {
+	// Scholar's mate position: White Qh5, Bc4 can play Qxf7#.
+	g, err := core.NewGameFromFEN("r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 4 3")
+	require.NoError(t, err)
+	action, newGame, ok := BasicAIAction(g, 0)
+	require.True(t, ok)
+	assert.True(t, newGame.IsCheckmate, "AI should choose checkmate; chose %v -> %v", action.FromPiece.XY.ToAlgebraic(), action.ToXY.ToAlgebraic())
+}
+
+func TestBasicAI_PrefersCapture(t *testing.T) {
+	// White Ka1, Nb3. Black Kh8, Qd4. Nxd4 captures the queen (9 material gain).
+	g, err := core.NewGameFromFEN("7k/8/8/8/3q4/1N6/8/K7 w - - 0 1")
+	require.NoError(t, err)
+	action, _, ok := BasicAIAction(g, 0)
+	require.True(t, ok)
+	assert.True(t, action.IsCapture, "AI should prefer capturing the queen; chose %v -> %v", action.FromPiece.XY.ToAlgebraic(), action.ToXY.ToAlgebraic())
+}
+
+func TestBasicAI_PromotesToQueen(t *testing.T) {
+	// White Kb2, Pf7. Black Kh8. f8=Q promotes.
+	g, err := core.NewGameFromFEN("7k/5P2/8/8/8/8/1K6/8 w - - 0 1")
+	require.NoError(t, err)
+	action, _, ok := BasicAIAction(g, 0)
+	require.True(t, ok)
+	assert.True(t, action.IsPromotion)
+	assert.Equal(t, core.PieceType(core.PieceQueen), action.PromotionPieceType)
+}
+
+func TestBasicAI_GameOverReturnsNoMove(t *testing.T) {
+	// Scholar's mate final position.
+	g, err := core.NewGameFromFEN("r1bqkb1r/pppp1Qpp/2n2n2/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4")
+	require.NoError(t, err)
+	_, _, ok := BasicAIAction(g, 0)
+	assert.False(t, ok)
+}
+
+func TestBasicAI_Depth1(t *testing.T) {
+	g := core.NewDefaultGame()
+	action, newGame, ok := BasicAIAction(g, 1)
+	require.True(t, ok)
+	assert.NotEqual(t, core.Action{}, action)
+	assert.NotEqual(t, g.ToFEN(), newGame.ToFEN())
+}
+
+func TestBasicAI_Depth2(t *testing.T) {
+	// Endgame position for speed; depth 2 from the default position is slow.
+	g, err := core.NewGameFromFEN("7k/5P2/8/8/3n4/1B6/8/K7 w - - 0 1")
+	require.NoError(t, err)
+	action, newGame, ok := BasicAIAction(g, 2)
+	require.True(t, ok)
+	assert.NotEqual(t, core.Action{}, action)
+	assert.NotEqual(t, g.ToFEN(), newGame.ToFEN())
+}
+
+func TestBasicAI_AutoplayGameCompletes(t *testing.T) {
+	// Two AI agents play against each other until the game ends or 200 moves.
+	g := core.NewDefaultGame()
+	for i := 0; i < 200 && !g.IsGameOver; i++ {
+		_, newGame, ok := BasicAIAction(g, 0)
+		if !ok {
+			break
+		}
+		g = newGame
+	}
+	// The game should eventually end (checkmate, stalemate, or draw).
+	// No panic means the AI produced valid moves throughout.
+}

--- a/api/api.go
+++ b/api/api.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"errors"
+	"math/rand"
 	"strings"
 
+	"github.com/marianogappa/cheesse/ai"
 	"github.com/marianogappa/cheesse/core"
 	"github.com/marianogappa/cheesse/parser"
 	"github.com/marianogappa/cheesse/parser/pgn"
@@ -213,6 +215,59 @@ func (a API) ConvertNotation(game InputGame, notationString string, targetNotati
 	return mapGameToOutputGame(parsedGame), result, nil
 }
 
+// AIMove selects a move for the side to move in the given game.
+//
+// `mode` must be one of: `{random|easy|medium|hard}` (case-insensitive).
+//   - `random`: uniformly random legal action (non-resign).
+//   - `easy`: minimax depth 0 (evaluates each move, no lookahead).
+//   - `medium`: minimax depth 1 (looks one full move ahead).
+//   - `hard`: minimax depth 2 (looks two full moves ahead).
+//
+// Returns the resulting game AFTER the action is applied, the chosen action, and
+// whether a move was available (false = game is already over).
+//
+// An error is only returned if the input game itself is invalid or mode is unknown.
+func (a API) AIMove(game InputGame, mode string) (OutputGame, OutputAction, bool, error) {
+	parsedGame, err := a.parseGame(game)
+	if err != nil {
+		return OutputGame{}, OutputAction{}, false, err
+	}
+
+	var (
+		action  core.Action
+		newGame core.Game
+		ok      bool
+	)
+	switch strings.ToLower(mode) {
+	case "random":
+		action, newGame, ok = ai.RandomAction(parsedGame, rand.New(rand.NewSource(rand.Int63())))
+	case "easy":
+		action, newGame, ok = ai.BasicAIAction(parsedGame, 0)
+	case "medium":
+		action, newGame, ok = ai.BasicAIAction(parsedGame, 1)
+	case "hard":
+		action, newGame, ok = ai.BasicAIAction(parsedGame, 2)
+	default:
+		return OutputGame{}, OutputAction{}, false, errUnknownAIMode
+	}
+
+	if !ok {
+		return mapGameToOutputGame(parsedGame), OutputAction{}, false, nil
+	}
+
+	outputAction := mapInternalActionToAction(action)
+	actionString, err := printer.AlgebraicPrinter{}.PrintAction(
+		core.GameStep{StepAction: action, StepGame: newGame, StepPreMoveGame: parsedGame},
+		printer.SANCharacteristics(),
+	)
+	if err == nil {
+		outputAction.ActionString = actionString
+	}
+
+	return mapGameToOutputGame(newGame), outputAction, true, nil
+}
+
+var errUnknownAIMode = errors.New("unknown AI mode: please use one of {random|easy|medium|hard}")
 var errUnknownTargetNotation = errors.New("unknown target notation: please use one of {Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith}")
 
 func notationPrinter(targetNotation string) (printer.NotationPrinter, printer.GameCharacteristics, error) {

--- a/handlers.go
+++ b/handlers.go
@@ -184,6 +184,30 @@ func handleCliConvertNotation(flagConvertNotation *string) {
 	fmt.Println(string(byts))
 }
 
+func handleServerAIMove(w http.ResponseWriter, r *http.Request) {
+	type args struct {
+		Game api.InputGame `json:"game"`
+		Mode string        `json:"mode"`
+	}
+	var input args
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	defer r.Body.Close()
+	outputGame, outputAction, moveAvailable, err := a.AIMove(input.Game, input.Mode)
+	if err != nil {
+		fmt.Fprintln(w, formatError(err))
+		return
+	}
+	type out struct {
+		Game          api.OutputGame   `json:"game"`
+		Action        api.OutputAction `json:"action"`
+		MoveAvailable bool             `json:"moveAvailable"`
+	}
+	json.NewEncoder(w).Encode(out{outputGame, outputAction, moveAvailable})
+}
+
 func mustCliFatal(err error) {
 	fmt.Println(formatError(err))
 	os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	http.HandleFunc("/doAction", handleServerDoAction)
 	http.HandleFunc("/parseNotation", handleServerParseNotation)
 	http.HandleFunc("/convertNotation", handleServerConvertNotation)
+	http.HandleFunc("/aiMove", handleServerAIMove)
 
 	switch {
 	case *flagServe != 0:

--- a/main_js.go
+++ b/main_js.go
@@ -59,12 +59,23 @@ func ConvertNotation(this js.Value, p []js.Value) interface{} {
 	})
 }
 
+func AIMove(this js.Value, p []js.Value) interface{} {
+	og, oa, ok, err := a.AIMove(convertToInputGame(p[0]), p[1].String())
+	return js.ValueOf(map[string]interface{}{
+		"outputGame":   convertOutputGame(og),
+		"outputAction": convertOutputAction(oa),
+		"moveAvailable": ok,
+		"error":        convertError(err),
+	})
+}
+
 func main() {
 	js.Global().Set("DefaultGame", js.FuncOf(DefaultGame))
 	js.Global().Set("ParseGame", js.FuncOf(ParseGame))
 	js.Global().Set("DoAction", js.FuncOf(DoAction))
 	js.Global().Set("ParseNotation", js.FuncOf(ParseNotation))
 	js.Global().Set("ConvertNotation", js.FuncOf(ConvertNotation))
+	js.Global().Set("AIMove", js.FuncOf(AIMove))
 	select {}
 }
 


### PR DESCRIPTION
Adds an ai/ package with RandomAction (seedable) and BasicAIAction (minimax + alpha-beta at configurable depth), exposed as AIMove(game, mode) with modes random/easy/medium/hard. Evaluation includes material, checkmate, check bonus, center control, and castling incentive. Fixes #18.