### PR TITLE
Complete draw detection: threefold repetition, insufficient material, fix 50-move rule

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,6 +23,7 @@ var (
 	errAlgebraicSquareInvalidOrOutOfBounds = errors.New("invalid algebraic square: empty or out of bounds")
 	errInvalidPieceTypeName                = errors.New("invalid piece type name: please use one of {Queen|King|Bishop|Knight|Rook|Pawn} or empty string")
 	errInvalidActionForGivenGame           = errors.New("the specified action is invalid for the specified game")
+	errInvalidPositionHistory              = errors.New("invalid position history: entries must be hex-encoded position hashes from a previous response")
 )
 
 // DefaultGame returns the initial game of chess, with all pieces on their default positions

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strconv"
+
 	"github.com/marianogappa/cheesse/core"
 )
 
@@ -15,9 +17,14 @@ import (
 // 3. via empty struct: assumes the defaultGame.
 //
 // If you supply both the `fenString` and the `board`, `board` is ignored silently.
+//
+// `positionHistory` is optional: pass the `positionHistory` of a previous OutputGame
+// to enable threefold/fivefold repetition detection across stateless API calls (the
+// entries are opaque position hashes). Without it, repetitions cannot be detected.
 type InputGame struct {
-	FENString string `json:"fenString"`
-	Board     Board  `json:"board"`
+	FENString       string   `json:"fenString"`
+	Board           Board    `json:"board"`
+	PositionHistory []string `json:"positionHistory"`
 }
 
 // InputAction is the input interface to supply a chess action.
@@ -113,9 +120,11 @@ type OutputGame struct {
 	IsCheckmate             bool              `json:"isCheckmate"`
 	IsStalemate             bool              `json:"isStalemate"`
 	IsDraw                  bool              `json:"isDraw"`
+	CanClaimDraw            bool              `json:"canClaimDraw"`
 	IsGameOver              bool              `json:"isGameOver"`
 	GameOverWinner          string            `json:"gameOverWinner"`
 	InCheckBy               []string          `json:"inCheckBy"`
+	PositionHistory         []string          `json:"positionHistory"`
 }
 
 // OutputAction is the output interface that describes a chess action.
@@ -233,9 +242,16 @@ func mapGameToOutputGame(g core.Game) OutputGame {
 	o.IsCheckmate = g.IsCheckmate
 	o.IsStalemate = g.IsStalemate
 	o.IsDraw = g.IsDraw
+	o.CanClaimDraw = g.CanClaimDraw
 	o.IsGameOver = g.IsGameOver
 	o.GameOverWinner = g.GameOverWinner.String()
 	o.InCheckBy = make([]string, len(g.InCheckBy))
+
+	history := g.PositionHistory()
+	o.PositionHistory = make([]string, len(history))
+	for i, h := range history {
+		o.PositionHistory[i] = strconv.FormatUint(h, 16)
+	}
 
 	for i := range g.Actions {
 		o.Actions[i] = mapInternalActionToAction(g.Actions[i])

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -90,6 +90,7 @@ func TestAPIDefaultGame(t *testing.T) {
 	}
 	actual := New().DefaultGame()
 	actual.Actions = []OutputAction{} // Not testing every single action on this test
+	actual.PositionHistory = nil      // Opaque hashes; covered by core draw tests
 	assert.Equal(t, expected, actual)
 }
 

--- a/api/api_utils.go
+++ b/api/api_utils.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/marianogappa/cheesse/core"
@@ -22,6 +23,15 @@ func (a API) parseGame(g InputGame) (core.Game, error) {
 	}
 	if err != nil {
 		return core.Game{}, err
+	}
+	if len(g.PositionHistory) > 0 {
+		history := make([]uint64, len(g.PositionHistory))
+		for i, s := range g.PositionHistory {
+			if history[i], err = strconv.ParseUint(s, 16, 64); err != nil {
+				return core.Game{}, errInvalidPositionHistory
+			}
+		}
+		parsedGame = parsedGame.WithPositionHistory(history)
 	}
 	return parsedGame, nil
 }

--- a/core/board.go
+++ b/core/board.go
@@ -154,6 +154,7 @@ func NewGameFromBoard(b Board) (Game, error) {
 		return Game{}, errBoardSideNotToMoveInCheck
 	}
 
+	g.positionHistory = []uint64{g.positionHash()}
 	return g.calculateCriticalFlags(), nil
 }
 

--- a/core/chess.go
+++ b/core/chess.go
@@ -14,10 +14,12 @@ func (g Game) shallowCloneForMove() Game {
 	clonedGame.IsCheckmate = false
 	clonedGame.IsStalemate = false
 	clonedGame.IsDraw = false
+	clonedGame.CanClaimDraw = false
 	clonedGame.IsGameOver = false
 	clonedGame.GameOverWinner = 0
 	clonedGame.InCheckBy = nil
 	clonedGame.Actions = nil
+	clonedGame.positionHistory = nil
 	return clonedGame
 }
 
@@ -320,6 +322,13 @@ func (g Game) DoAction(a Action) Game {
 		newGame.HalfMoveClock = 0
 	}
 
+	// Maintain position history for repetition detection. Captures and pawn moves are
+	// irreversible, so earlier positions can never repeat and the history restarts.
+	if newGame.HalfMoveClock > 0 {
+		newGame.positionHistory = append(newGame.positionHistory, g.positionHistory...)
+	}
+	newGame.positionHistory = append(newGame.positionHistory, newGame.positionHash())
+
 	newGame = newGame.calculateCriticalFlags()
 
 	if newGame.IsCheck {
@@ -347,6 +356,7 @@ func (g Game) calculateCriticalFlags() Game {
 	g.IsCheckmate = false
 	g.IsStalemate = false
 	g.IsDraw = false
+	g.CanClaimDraw = false
 	g.IsGameOver = false
 	g.GameOverWinner = -1
 	g.InCheckBy = []Piece{}
@@ -362,9 +372,17 @@ func (g Game) calculateCriticalFlags() Game {
 		g.IsStalemate = !g.IsCheck
 	}
 
-	if g.HalfMoveClock == 100 {
-		g.IsDraw = true // N.B. this forces draw rather than allowing a claim for draw. Is that ok?
+	// Draw rules, per FIDE: the 75-move rule, fivefold repetition and insufficient
+	// material (dead position) end the game automatically; the 50-move rule and
+	// threefold repetition make a draw claimable by the player to move.
+	repetitions := g.repetitionCount()
+	switch {
+	case g.HalfMoveClock >= 150, repetitions >= 5, g.isInsufficientMaterial():
+		g.IsDraw = true
+	case g.HalfMoveClock >= 100, repetitions >= 3:
+		g.CanClaimDraw = true
 	}
+
 	if g.IsCheckmate || g.IsStalemate || g.IsDraw {
 		g.IsGameOver = true
 	}
@@ -373,6 +391,49 @@ func (g Game) calculateCriticalFlags() Game {
 	}
 
 	return g
+}
+
+// repetitionCount returns how many times the current position has occurred, based on
+// the position history since the last irreversible move.
+func (g Game) repetitionCount() int {
+	if len(g.positionHistory) == 0 {
+		return 0
+	}
+	current := g.positionHistory[len(g.positionHistory)-1]
+	count := 0
+	for _, h := range g.positionHistory {
+		if h == current {
+			count++
+		}
+	}
+	return count
+}
+
+// isInsufficientMaterial reports whether neither side can possibly checkmate: K vs K,
+// KB vs K, KN vs K, and KB vs KB with both bishops on the same color complex.
+func (g Game) isInsufficientMaterial() bool {
+	// Any pawn, rook or queen is (potentially) sufficient material.
+	if g.bb[ColorBlack][PiecePawn]|g.bb[ColorWhite][PiecePawn]|
+		g.bb[ColorBlack][PieceRook]|g.bb[ColorWhite][PieceRook]|
+		g.bb[ColorBlack][PieceQueen]|g.bb[ColorWhite][PieceQueen] != 0 {
+		return false
+	}
+	bishops := g.bb[ColorBlack][PieceBishop] | g.bb[ColorWhite][PieceBishop]
+	knights := g.bb[ColorBlack][PieceKnight] | g.bb[ColorWhite][PieceKnight]
+	minorCount := bits.OnesCount64(bishops | knights)
+	if minorCount <= 1 {
+		return true // K vs K, KB vs K, KN vs K
+	}
+	// KB vs KB with same-color bishops: only bishops remain, one per side, on the
+	// same color complex.
+	const lightSquares = 0x55AA55AA55AA55AA
+	if knights == 0 &&
+		bits.OnesCount64(g.bb[ColorBlack][PieceBishop]) == 1 &&
+		bits.OnesCount64(g.bb[ColorWhite][PieceBishop]) == 1 &&
+		(bishops&lightSquares == bishops || bishops&lightSquares == 0) {
+		return true
+	}
+	return false
 }
 
 func opponent(c color) color {

--- a/core/draw_test.go
+++ b/core/draw_test.go
@@ -1,0 +1,209 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsufficientMaterial(t *testing.T) {
+	ts := []struct {
+		name   string
+		fen    string
+		isDraw bool
+	}{
+		{
+			name:   "K vs K",
+			fen:    "8/8/4k3/8/8/4K3/8/8 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name:   "KB vs K (white bishop)",
+			fen:    "8/8/4k3/8/8/2B1K3/8/8 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name:   "KB vs K (black bishop)",
+			fen:    "8/8/2b1k3/8/8/4K3/8/8 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name:   "KN vs K (white knight)",
+			fen:    "8/8/4k3/8/8/2N1K3/8/8 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name:   "KN vs K (black knight)",
+			fen:    "8/8/2n1k3/8/8/4K3/8/8 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name: "KB vs KB with same-color bishops",
+			// c1 and f4 are both dark squares
+			fen:    "8/8/4k3/8/5b2/4K3/8/2B5 w - - 0 1",
+			isDraw: true,
+		},
+		{
+			name: "KB vs KB with opposite-color bishops is not a draw",
+			// c1 dark, e4 light
+			fen:    "8/8/4k3/8/4b3/4K3/8/2B5 w - - 0 1",
+			isDraw: false,
+		},
+		{
+			name:   "KNN vs K is not automatically a draw",
+			fen:    "8/8/4k3/8/8/1NN1K3/8/8 w - - 0 1",
+			isDraw: false,
+		},
+		{
+			name:   "K vs K with a pawn is not a draw",
+			fen:    "8/8/4k3/8/8/4K3/4P3/8 w - - 0 1",
+			isDraw: false,
+		},
+		{
+			name:   "K vs K with a rook is not a draw",
+			fen:    "8/8/4k3/8/8/4K3/8/6R1 w - - 0 1",
+			isDraw: false,
+		},
+		{
+			name:   "K vs K with a queen is not a draw",
+			fen:    "8/8/4k3/8/8/4K3/8/6Q1 w - - 0 1",
+			isDraw: false,
+		},
+	}
+	for _, tc := range ts {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := NewGameFromFEN(tc.fen)
+			require.NoError(t, err)
+			assert.Equal(t, tc.isDraw, g.IsDraw)
+			assert.Equal(t, tc.isDraw, g.IsGameOver)
+		})
+	}
+}
+
+func TestFiftyMoveRule(t *testing.T) {
+	t.Run("clock at 99 is not claimable", func(t *testing.T) {
+		g, err := NewGameFromFEN("8/8/4k3/8/8/4K3/8/6R1 w - - 99 80")
+		require.NoError(t, err)
+		assert.False(t, g.CanClaimDraw)
+		assert.False(t, g.IsDraw)
+	})
+	t.Run("clock at 100 is claimable but not automatic", func(t *testing.T) {
+		g, err := NewGameFromFEN("8/8/4k3/8/8/4K3/8/6R1 w - - 100 80")
+		require.NoError(t, err)
+		assert.True(t, g.CanClaimDraw)
+		assert.False(t, g.IsDraw)
+		assert.False(t, g.IsGameOver)
+	})
+	t.Run("clock above 100 is still claimable (no exact-equality bug)", func(t *testing.T) {
+		g, err := NewGameFromFEN("8/8/4k3/8/8/4K3/8/6R1 w - - 120 90")
+		require.NoError(t, err)
+		assert.True(t, g.CanClaimDraw)
+		assert.False(t, g.IsDraw)
+	})
+	t.Run("clock at 150 is an automatic draw (75-move rule)", func(t *testing.T) {
+		g, err := NewGameFromFEN("8/8/4k3/8/8/4K3/8/6R1 w - - 150 100")
+		require.NoError(t, err)
+		assert.True(t, g.IsDraw)
+		assert.True(t, g.IsGameOver)
+	})
+	t.Run("clock reached via DoAction", func(t *testing.T) {
+		g, err := NewGameFromFEN("8/8/4k3/8/8/4K3/8/6R1 w - - 99 80")
+		require.NoError(t, err)
+		var action Action
+		for _, a := range g.Actions {
+			if a.FromPiece.PieceType == PieceRook && !a.IsCapture {
+				action = a
+				break
+			}
+		}
+		require.NotEqual(t, Action{}, action)
+		newGame := g.DoAction(action)
+		assert.Equal(t, 100, newGame.HalfMoveClock)
+		assert.True(t, newGame.CanClaimDraw)
+		assert.False(t, newGame.IsDraw)
+	})
+}
+
+// doMoves applies a sequence of from→to moves in algebraic-square pairs.
+func doMoves(t *testing.T, g Game, moves ...string) Game {
+	t.Helper()
+	for i := 0; i < len(moves); i += 2 {
+		from := XY{int(moves[i][0] - 'a'), int('8' - moves[i][1])}
+		to := XY{int(moves[i+1][0] - 'a'), int('8' - moves[i+1][1])}
+		var action Action
+		for _, a := range g.Actions {
+			if !a.IsResign && a.FromPiece.XY == from && a.ToXY == to {
+				action = a
+				break
+			}
+		}
+		require.NotEqual(t, Action{}, action, "move %s%s not found", moves[i], moves[i+1])
+		g = g.DoAction(action)
+	}
+	return g
+}
+
+func TestThreefoldRepetition(t *testing.T) {
+	t.Run("shuffling knights back and forth reaches threefold", func(t *testing.T) {
+		g := NewDefaultGame()
+
+		// Ng1-f3 Ng8-f6 Nf3-g1 Nf6-g8 repeats the starting position; twice over reaches
+		// the third occurrence of the initial position.
+		g = doMoves(t, g,
+			"g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8", // initial position x2
+			"g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8", // initial position x3
+		)
+		assert.True(t, g.CanClaimDraw, "third occurrence should be claimable")
+		assert.False(t, g.IsDraw, "threefold is claimable, not automatic")
+		assert.False(t, g.IsGameOver)
+	})
+
+	t.Run("two occurrences is not claimable", func(t *testing.T) {
+		g := NewDefaultGame()
+		g = doMoves(t, g, "g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8")
+		assert.False(t, g.CanClaimDraw)
+	})
+
+	t.Run("fivefold repetition is an automatic draw", func(t *testing.T) {
+		g := NewDefaultGame()
+		for i := 0; i < 4; i++ {
+			g = doMoves(t, g, "g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8")
+		}
+		assert.True(t, g.IsDraw)
+		assert.True(t, g.IsGameOver)
+	})
+
+	t.Run("pawn move resets repetition tracking", func(t *testing.T) {
+		g := NewDefaultGame()
+		g = doMoves(t, g,
+			"g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8",
+			"e2", "e4", "e7", "e5", // irreversible: history restarts
+			"g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8",
+		)
+		assert.False(t, g.CanClaimDraw, "repetitions before a pawn move don't count")
+	})
+
+	t.Run("history crosses stateless boundary via WithPositionHistory", func(t *testing.T) {
+		g := NewDefaultGame()
+		g = doMoves(t, g, "g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8")
+		history := g.PositionHistory()
+
+		// Reconstruct the same position from FEN (stateless boundary) and restore history.
+		restored, err := NewGameFromFEN(g.ToFEN())
+		require.NoError(t, err)
+		restored = restored.WithPositionHistory(history)
+
+		restored = doMoves(t, restored, "g1", "f3", "g8", "f6", "f3", "g1", "f6", "g8")
+		assert.True(t, restored.CanClaimDraw, "restored history should enable threefold detection")
+	})
+}
+
+func TestStalemateIsNotAffectedByDrawRules(t *testing.T) {
+	// Classic stalemate: black king on a8, white queen on b6, white king on c6; black to move.
+	g, err := NewGameFromFEN("k7/8/1QK5/8/8/8/8/8 b - - 0 1")
+	require.NoError(t, err)
+	assert.True(t, g.IsStalemate)
+	assert.True(t, g.IsGameOver)
+	assert.False(t, g.IsCheckmate)
+}

--- a/core/entities.go
+++ b/core/entities.go
@@ -28,10 +28,39 @@ type Game struct {
 	IsCheckmate             bool
 	IsStalemate             bool
 	IsDraw                  bool
+	CanClaimDraw            bool
 	IsGameOver              bool
 	GameOverWinner          color
 	InCheckBy               []Piece
 	Actions                 []Action
+	// positionHistory holds the Zobrist hashes of positions reached since the last
+	// irreversible move (pawn move, capture or castling-right change), most recent
+	// last. Used for threefold/fivefold repetition detection.
+	positionHistory []uint64
+}
+
+// PositionHistory returns the Zobrist hashes of the positions reached since the
+// last irreversible move, most recent last. It can be persisted and restored via
+// WithPositionHistory to detect repetitions across stateless API calls.
+func (g Game) PositionHistory() []uint64 {
+	history := make([]uint64, len(g.positionHistory))
+	copy(history, g.positionHistory)
+	return history
+}
+
+// WithPositionHistory returns a copy of the game whose position history is the given
+// hashes (as returned by PositionHistory of a previous game), and with draw flags
+// recalculated accordingly. The current position is appended if it isn't already the
+// last entry, so both "history up to and including this position" and "history of
+// prior positions" are accepted.
+func (g Game) WithPositionHistory(history []uint64) Game {
+	currentHash := g.positionHash()
+	g.positionHistory = make([]uint64, 0, len(history)+1)
+	g.positionHistory = append(g.positionHistory, history...)
+	if len(g.positionHistory) == 0 || g.positionHistory[len(g.positionHistory)-1] != currentHash {
+		g.positionHistory = append(g.positionHistory, currentHash)
+	}
+	return g.calculateCriticalFlags()
 }
 
 // Color is the exported name for the color of a player or piece (e.g. core.ColorWhite).
@@ -75,6 +104,8 @@ func (g Game) Clone() Game {
 	copy(clonedGame.InCheckBy, g.InCheckBy)
 	clonedGame.Actions = make([]Action, len(g.Actions))
 	copy(clonedGame.Actions, g.Actions)
+	clonedGame.positionHistory = make([]uint64, len(g.positionHistory))
+	copy(clonedGame.positionHistory, g.positionHistory)
 	return clonedGame
 }
 

--- a/core/fen.go
+++ b/core/fen.go
@@ -141,6 +141,7 @@ func NewGameFromFEN(s string) (Game, error) {
 		return Game{}, errFENSideNotToMoveInCheck
 	}
 
+	game.positionHistory = []uint64{game.positionHash()}
 	return game.calculateCriticalFlags(), nil
 }
 

--- a/core/zobrist.go
+++ b/core/zobrist.go
@@ -1,0 +1,72 @@
+package core
+
+import "math/bits"
+
+// Zobrist hashing: a position (placement + turn + castling rights + e.p. target)
+// maps to a uint64 by xoring per-feature random keys. Used to detect repetitions.
+// https://www.chessprogramming.org/Zobrist_Hashing
+
+var (
+	zobristPieces        [2][7][64]uint64
+	zobristWhiteTurn     uint64
+	zobristCastling      [4]uint64 // WK, WQ, BK, BQ
+	zobristEnPassantFile [8]uint64
+)
+
+func init() {
+	// SplitMix64 with a fixed seed: keys must be deterministic across runs so that
+	// hashes seeded from previous positions (e.g. via the API) remain comparable.
+	state := uint64(0x9E3779B97F4A7C15)
+	next := func() uint64 {
+		state += 0x9E3779B97F4A7C15
+		z := state
+		z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+		z = (z ^ (z >> 27)) * 0x94D049BB133111EB
+		return z ^ (z >> 31)
+	}
+	for c := 0; c < 2; c++ {
+		for t := PieceQueen; t <= PiecePawn; t++ {
+			for sq := 0; sq < 64; sq++ {
+				zobristPieces[c][t][sq] = next()
+			}
+		}
+	}
+	zobristWhiteTurn = next()
+	for i := range zobristCastling {
+		zobristCastling[i] = next()
+	}
+	for i := range zobristEnPassantFile {
+		zobristEnPassantFile[i] = next()
+	}
+}
+
+// positionHash returns the Zobrist hash of the position for repetition purposes:
+// piece placement, side to move, castling rights and en passant target square.
+func (g Game) positionHash() uint64 {
+	h := uint64(0)
+	for c := 0; c < 2; c++ {
+		for occ := g.occ[c]; occ != 0; occ &= occ - 1 {
+			sq := bits.TrailingZeros64(occ)
+			h ^= zobristPieces[c][g.squares[sq]>>1][sq]
+		}
+	}
+	if g.Turn() == ColorWhite {
+		h ^= zobristWhiteTurn
+	}
+	if g.CanWhiteKingsideCastle {
+		h ^= zobristCastling[0]
+	}
+	if g.CanWhiteQueensideCastle {
+		h ^= zobristCastling[1]
+	}
+	if g.CanBlackKingsideCastle {
+		h ^= zobristCastling[2]
+	}
+	if g.CanBlackQueensideCastle {
+		h ^= zobristCastling[3]
+	}
+	if g.IsLastMoveEnPassant {
+		h ^= zobristEnPassantFile[g.EnPassantTargetSquare.X]
+	}
+	return h
+}


### PR DESCRIPTION
Adds Zobrist-based repetition tracking, insufficient-material detection, and FIDE claimable/automatic draw semantics (CanClaimDraw vs IsDraw), with position history crossing the stateless API boundary via an opaque positionHistory field. Closes #19.