### PR TITLE
"Draw" action should be available

### DIFF
--- a/ai/ai.go
+++ b/ai/ai.go
@@ -50,7 +50,7 @@ func BasicAIAction(g core.Game, depth int) (core.Action, core.Game, bool) {
 func nonResignActions(g core.Game) []core.Action {
 	out := make([]core.Action, 0, len(g.Actions))
 	for _, a := range g.Actions {
-		if !a.IsResign {
+		if !a.IsResign && !a.IsDraw {
 			out = append(out, a)
 		}
 	}

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -29,16 +29,22 @@ type InputGame struct {
 
 // InputAction is the input interface to supply a chess action.
 //
-// - `fromSquare` and `toSquare` are required, and must be board cells described in
-// Algebraic Notation (e.g. `e2`). Note that `a1` is where the White Queen's Rook starts.
+// - `fromSquare` and `toSquare` are required (unless `isResign` or `isDraw` is set),
+// and must be board cells described in Algebraic Notation (e.g. `e2`). Note that
+// `a1` is where the White Queen's Rook starts.
 //
 // - `promotionPieceType` is only required if the action is a promotion.
 //
 // - `promotionPieceType` must be one of: `{Queen|King|Bishop|Knight|Rook|Pawn}`.
+//
+// - `isResign` resigns the game for the player to move; `isDraw` proposes a draw,
+// which the engine assumes accepted. When either is set, the other fields are ignored.
 type InputAction struct {
 	FromSquare         string `json:"fromSquare"`
 	ToSquare           string `json:"toSquare"`
 	PromotionPieceType string `json:"promotionPieceType"`
+	IsResign           bool   `json:"isResign"`
+	IsDraw             bool   `json:"isDraw"`
 }
 
 // Board is one of the input interfaces to supply a chess game.
@@ -157,6 +163,7 @@ type OutputAction struct {
 	ToSquare           string `json:"toSquare"`
 	IsCapture          bool   `json:"isCapture"`
 	IsResign           bool   `json:"isResign"`
+	IsDraw             bool   `json:"isDraw"`
 	IsPromotion        bool   `json:"isPromotion"`
 	IsEnPassantCapture bool   `json:"isEnPassantCapture"`
 	IsCastle           bool   `json:"isCastle"`
@@ -312,6 +319,7 @@ func mapInternalActionToAction(a core.Action) OutputAction {
 		ToSquare:           a.ToXY.ToAlgebraic(),
 		IsCapture:          a.IsCapture,
 		IsResign:           a.IsResign,
+		IsDraw:             a.IsDraw,
 		IsPromotion:        a.IsPromotion,
 		IsEnPassantCapture: a.IsEnPassantCapture,
 		IsCastle:           a.IsCastle,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -458,3 +458,33 @@ func TestDoAction(t *testing.T) {
 		})
 	}
 }
+
+func TestDoActionDraw(t *testing.T) {
+	outputGame, outputAction, err := New().DoAction(InputGame{}, InputAction{IsDraw: true})
+	require.NoError(t, err)
+	assert.True(t, outputAction.IsDraw)
+	assert.Equal(t, "White", outputAction.FromPieceOwner)
+	assert.True(t, outputGame.IsDraw)
+	assert.True(t, outputGame.IsGameOver)
+	assert.Equal(t, "Unknown", outputGame.GameOverWinner)
+}
+
+func TestDoActionResign(t *testing.T) {
+	outputGame, outputAction, err := New().DoAction(InputGame{}, InputAction{IsResign: true})
+	require.NoError(t, err)
+	assert.True(t, outputAction.IsResign)
+	assert.True(t, outputGame.IsGameOver)
+	assert.Equal(t, "Black", outputGame.GameOverWinner)
+}
+
+func TestDrawActionIsAvailable(t *testing.T) {
+	outputGame, err := New().ParseGame(InputGame{})
+	require.NoError(t, err)
+	hasDraw := false
+	for _, a := range outputGame.Actions {
+		if a.IsDraw {
+			hasDraw = true
+		}
+	}
+	assert.True(t, hasDraw, "draw action should be among the available actions")
+}

--- a/api/api_utils.go
+++ b/api/api_utils.go
@@ -37,6 +37,16 @@ func (a API) parseGame(g InputGame) (core.Game, error) {
 }
 
 func (a API) parseAction(ia InputAction, g core.Game) (core.Action, error) {
+	// Terminal actions don't carry squares; match them directly.
+	if ia.IsResign || ia.IsDraw {
+		for _, action := range g.Actions {
+			if action.IsResign == ia.IsResign && action.IsDraw == ia.IsDraw {
+				return action, nil
+			}
+		}
+		return core.Action{}, errInvalidActionForGivenGame
+	}
+
 	// TODO eventually accept other forms of action input
 	fromXY, err := a.algebraicToXY(strings.ToLower(ia.FromSquare))
 	if err != nil {
@@ -56,6 +66,9 @@ func (a API) parseAction(ia InputAction, g core.Game) (core.Action, error) {
 	}
 
 	for _, action := range g.Actions {
+		if action.IsResign || action.IsDraw {
+			continue // Terminal actions carry no squares; matched above.
+		}
 		if action.FromPiece.XY != fromXY || action.ToXY != toXY || (action.IsPromotion && action.PromotionPieceType != promotionPieceType) {
 			continue
 		}

--- a/core/benchmark_test.go
+++ b/core/benchmark_test.go
@@ -67,7 +67,7 @@ func perft(g Game, depth int) int {
 	}
 	nodes := 0
 	for _, action := range g.Actions {
-		if action.IsResign {
+		if action.IsResign || action.IsDraw {
 			continue
 		}
 		nodes += perft(g.DoAction(action), depth-1)

--- a/core/chess.go
+++ b/core/chess.go
@@ -31,8 +31,8 @@ func (g Game) shallowCloneForMove() Game {
 func (g Game) updateBoardLayout(a Action) Game {
 	clonedGame := g.shallowCloneForMove()
 
-	// Special case for resignation action, because it doesn't require board changes
-	if a.IsResign {
+	// Special case for resignation and draw actions, because they don't require board changes
+	if a.IsResign || a.IsDraw {
 		return clonedGame
 	}
 
@@ -77,7 +77,10 @@ func (g Game) calculateAllActions() []Action {
 	for occ := g.occ[turn]; occ != 0; occ &= occ - 1 {
 		actions = g.pieceAtSq(bits.TrailingZeros64(occ)).appendActions(actions, g)
 	}
+	// Terminal actions: resigning is always possible, and any player may propose a
+	// draw at any point (the engine assumes the opponent accepts).
 	actions = append(actions, Action{FromPiece: Piece{Owner: turn}, IsResign: true})
+	actions = append(actions, Action{FromPiece: Piece{Owner: turn}, IsDraw: true})
 	return actions
 }
 
@@ -262,6 +265,14 @@ func (g Game) DoAction(a Action) Game {
 		return newGame
 	}
 
+	// Special case for draw action (proposing a draw, assumed accepted)
+	if a.IsDraw {
+		newGame.IsGameOver = true
+		newGame.IsDraw = true
+		newGame.GameOverWinner = -1
+		return newGame
+	}
+
 	// Castling context update: moving player's king or rook
 	switch {
 	case lastTurn == ColorBlack && (a.IsCastle || a.FromPiece.PieceType == PieceKing):
@@ -367,7 +378,14 @@ func (g Game) calculateCriticalFlags() Game {
 	}
 
 	g.Actions = g.calculateAllActions() // This is incredibly expensive!
-	if len(g.Actions) == 1 && g.Actions[0].IsResign {
+	hasBoardActions := false
+	for _, a := range g.Actions {
+		if !a.IsResign && !a.IsDraw {
+			hasBoardActions = true
+			break
+		}
+	}
+	if !hasBoardActions && len(g.Actions) > 0 {
 		g.IsCheckmate = g.IsCheck
 		g.IsStalemate = !g.IsCheck
 	}

--- a/core/draw_test.go
+++ b/core/draw_test.go
@@ -199,6 +199,56 @@ func TestThreefoldRepetition(t *testing.T) {
 	})
 }
 
+func TestDrawAction(t *testing.T) {
+	t.Run("draw action is always available", func(t *testing.T) {
+		g := NewDefaultGame()
+		var drawAction Action
+		for _, a := range g.Actions {
+			if a.IsDraw {
+				drawAction = a
+			}
+		}
+		require.True(t, drawAction.IsDraw, "draw action should be among the available actions")
+		assert.Equal(t, color(ColorWhite), drawAction.FromPiece.Owner)
+	})
+
+	t.Run("doing the draw action ends the game in a draw", func(t *testing.T) {
+		g := NewDefaultGame()
+		var drawAction Action
+		for _, a := range g.Actions {
+			if a.IsDraw {
+				drawAction = a
+			}
+		}
+		newGame := g.DoAction(drawAction)
+		assert.True(t, newGame.IsDraw)
+		assert.True(t, newGame.IsGameOver)
+		assert.Equal(t, color(-1), newGame.GameOverWinner)
+		assert.False(t, newGame.IsCheckmate)
+		assert.False(t, newGame.IsStalemate)
+	})
+
+	t.Run("no actions after a draw", func(t *testing.T) {
+		g := NewDefaultGame()
+		var drawAction Action
+		for _, a := range g.Actions {
+			if a.IsDraw {
+				drawAction = a
+			}
+		}
+		newGame := g.DoAction(drawAction)
+		assert.Empty(t, newGame.calculateAllActions())
+	})
+
+	t.Run("checkmate detection is unaffected by the draw action's availability", func(t *testing.T) {
+		// Fool's mate
+		g := NewDefaultGame()
+		g = doMoves(t, g, "f2", "f3", "e7", "e5", "g2", "g4", "d8", "h4")
+		assert.True(t, g.IsCheckmate)
+		assert.True(t, g.IsGameOver)
+	})
+}
+
 func TestStalemateIsNotAffectedByDrawRules(t *testing.T) {
 	// Classic stalemate: black king on a8, white queen on b6, white king on c6; black to move.
 	g, err := NewGameFromFEN("k7/8/1QK5/8/8/8/8/8 b - - 0 1")

--- a/core/entities.go
+++ b/core/entities.go
@@ -121,6 +121,7 @@ type Action struct {
 	ToXY               XY
 	IsCapture          bool
 	IsResign           bool
+	IsDraw             bool
 	IsPromotion        bool
 	IsEnPassantCapture bool
 	IsCastle           bool
@@ -144,6 +145,8 @@ func (a Action) String() string {
 		return fmt.Sprintf("%s's %s at %v captures %s's %s at %v", a.FromPiece.Owner, a.FromPiece.PieceType, a.FromPiece.XY.ToAlgebraic(), a.CapturedPiece.Owner, a.CapturedPiece.PieceType, a.CapturedPiece.XY.ToAlgebraic())
 	case a.IsResign:
 		return fmt.Sprintf("%s resigns", a.FromPiece.Owner)
+	case a.IsDraw:
+		return fmt.Sprintf("%s draws", a.FromPiece.Owner)
 	case a.IsPromotion:
 		return fmt.Sprintf("%s's Pawn at %v promotes to %v", a.FromPiece.Owner, a.FromPiece.XY.ToAlgebraic(), a.PromotionPieceType)
 	case a.IsKingsideCastle:

--- a/core/perft.go
+++ b/core/perft.go
@@ -9,7 +9,7 @@ func Perft(g Game, depth int) int {
 	}
 	nodes := 0
 	for _, a := range g.Actions {
-		if a.IsResign {
+		if a.IsResign || a.IsDraw {
 			continue
 		}
 		nodes += Perft(g.DoAction(a), depth-1)

--- a/parser/end_of_game_test.go
+++ b/parser/end_of_game_test.go
@@ -12,19 +12,20 @@ func TestAlgebraicParserResultMarkers(t *testing.T) {
 	testCases := []struct {
 		name   string
 		marker string
+		isDraw bool
 	}{
-		{"ASCII 1-0", "1-0"},
-		{"en-dash 1–0", "1–0"},
-		{"ASCII 0-1", "0-1"},
-		{"en-dash 0–1", "0–1"},
-		{"ASCII ½-½", "½-½"},
-		{"en-dash ½–½", "½–½"},
-		{"ASCII 1/2-1/2", "1/2-1/2"},
-		{"en-dash 1/2–1/2", "1/2–1/2"},
-		{"resigns", "resigns"},
-		{"Resigns", "Resigns"},
-		{"White resigns", "White resigns"},
-		{"Black resigns", "Black resigns"},
+		{"ASCII 1-0", "1-0", false},
+		{"en-dash 1–0", "1–0", false},
+		{"ASCII 0-1", "0-1", false},
+		{"en-dash 0–1", "0–1", false},
+		{"ASCII ½-½", "½-½", true},
+		{"en-dash ½–½", "½–½", true},
+		{"ASCII 1/2-1/2", "1/2-1/2", true},
+		{"en-dash 1/2–1/2", "1/2–1/2", true},
+		{"resigns", "resigns", false},
+		{"Resigns", "Resigns", false},
+		{"White resigns", "White resigns", false},
+		{"Black resigns", "Black resigns", false},
 	}
 
 	for _, tc := range testCases {
@@ -33,7 +34,11 @@ func TestAlgebraicParserResultMarkers(t *testing.T) {
 			steps, err := NewNotationParserAlgebraic(Characteristics{}).Parse(core.NewDefaultGame(), game)
 			require.NoError(t, err, "result marker %q should parse", tc.marker)
 			require.Len(t, steps, 3)
-			assert.True(t, steps[2].StepAction.IsResign, "last step should be the terminal action")
+			if tc.isDraw {
+				assert.True(t, steps[2].StepAction.IsDraw, "draw marker should match the draw action")
+			} else {
+				assert.True(t, steps[2].StepAction.IsResign, "decisive marker should match the resign action")
+			}
 		})
 	}
 }
@@ -42,11 +47,12 @@ func TestDescriptiveParserResultMarkers(t *testing.T) {
 	testCases := []struct {
 		name   string
 		marker string
+		isDraw bool
 	}{
-		{"ASCII 1-0", "1-0"},
-		{"en-dash 1–0", "1–0"},
-		{"ASCII ½-½", "½-½"},
-		{"Resigns", "Resigns"},
+		{"ASCII 1-0", "1-0", false},
+		{"en-dash 1–0", "1–0", false},
+		{"ASCII ½-½", "½-½", true},
+		{"Resigns", "Resigns", false},
 	}
 
 	for _, tc := range testCases {
@@ -55,7 +61,11 @@ func TestDescriptiveParserResultMarkers(t *testing.T) {
 			steps, err := NewNotationParserDescriptive(Characteristics{}).Parse(core.NewDefaultGame(), game)
 			require.NoError(t, err, "result marker %q should parse", tc.marker)
 			require.Len(t, steps, 3)
-			assert.True(t, steps[2].StepAction.IsResign, "last step should be the terminal action")
+			if tc.isDraw {
+				assert.True(t, steps[2].StepAction.IsDraw, "draw marker should match the draw action")
+			} else {
+				assert.True(t, steps[2].StepAction.IsResign, "decisive marker should match the resign action")
+			}
 		})
 	}
 }

--- a/parser/notation_algebraic.go
+++ b/parser/notation_algebraic.go
@@ -292,9 +292,13 @@ const rxEndOfGame = `(1[–-]0|0[–-]1|½[–-]½|1/2[–-]1/2|White resigns|Bl
 // processEndOfGameToken interprets an end-of-game token (see rxEndOfGame).
 func processEndOfGameToken(ms []string, g core.Game) []tokenMatch {
 	normalized := strings.ReplaceAll(ms[1], "–", "-")
+	isDrawMarker := false
 	var usesEndGameSymbol string
 	switch normalized {
-	case "1-0", "0-1", "½-½", "1/2-1/2":
+	case "½-½", "1/2-1/2":
+		usesEndGameSymbol = "numbers"
+		isDrawMarker = true
+	case "1-0", "0-1":
 		usesEndGameSymbol = "numbers"
 	case "resigns":
 		usesEndGameSymbol = "resigns"
@@ -303,10 +307,10 @@ func processEndOfGameToken(ms []string, g core.Game) []tokenMatch {
 	case "White resigns", "Black resigns":
 		usesEndGameSymbol = "color resigns"
 	}
-	// The engine's only terminal action is resignation, so every end-of-game
-	// marker matches the resign action.
+	// Draw markers match the draw action; decisive markers match the resign action.
 	ap := actionPattern{
-		isResign:           pBool(true),
+		isResign:           pBool(!isDrawMarker),
+		isDraw:             pBool(isDrawMarker),
 		isPromotion:        pBool(false),
 		isCastle:           pBool(false),
 		isCapture:          pBool(false),

--- a/parser/notation_parser.go
+++ b/parser/notation_parser.go
@@ -23,6 +23,7 @@ type actionPattern struct {
 	toY                *int
 	isCapture          *bool
 	isResign           *bool
+	isDraw             *bool
 	isPromotion        *bool
 	isEnPassantCapture *bool
 	isCastle           *bool
@@ -45,6 +46,7 @@ func (p actionPattern) Clone() actionPattern {
 		toY:                cloneInt(p.toY),
 		isCapture:          cloneBool(p.isCapture),
 		isResign:           cloneBool(p.isResign),
+		isDraw:             cloneBool(p.isDraw),
 		isPromotion:        cloneBool(p.isPromotion),
 		isEnPassantCapture: cloneBool(p.isEnPassantCapture),
 		isCastle:           cloneBool(p.isCastle),
@@ -130,6 +132,11 @@ func (p actionPattern) String() string {
 }
 
 func (p *actionPattern) isMatch(a core.Action) bool {
+	// A draw action can never be inferred from a move string: only a pattern that
+	// explicitly targets it may match (no notation pattern does so at present).
+	if a.IsDraw && (p.isDraw == nil || !*p.isDraw) {
+		return false
+	}
 	if !pieceTypeMatcher(p.fromPieceType)(a.FromPiece.PieceType) ||
 		!intMatcher(p.fromX)(a.FromPiece.XY.X) ||
 		!intMatcher(p.fromY)(a.FromPiece.XY.Y) ||
@@ -137,6 +144,7 @@ func (p *actionPattern) isMatch(a core.Action) bool {
 		!intMatcher(p.toY)(a.ToXY.Y) ||
 		!boolMatcher(p.isCapture)(a.IsCapture) ||
 		!boolMatcher(p.isResign)(a.IsResign) ||
+		!boolMatcher(p.isDraw)(a.IsDraw) ||
 		!boolMatcher(p.isPromotion)(a.IsPromotion) ||
 		!boolMatcher(p.isEnPassantCapture)(a.IsEnPassantCapture) ||
 		!boolMatcher(p.isCastle)(a.IsCastle) ||

--- a/parser/pgn/variant.go
+++ b/parser/pgn/variant.go
@@ -149,6 +149,10 @@ func (p *VariantPGN) Finalize(pg *parser.ParsingGame) error {
 
 // ActionToStringVariants implements ParserVariant.ActionToStringVariants for PGN.
 func (p *VariantPGN) ActionToStringVariants(a core.Action, g core.Game) []string {
+	// Terminal actions have no move notation: results are handled as result tokens.
+	if a.IsResign || a.IsDraw {
+		return nil
+	}
 	if a.IsKingsideCastle {
 		return []string{"O-O", "O-O+", "O-O#", "0-0", "0-0+", "0-0#"}
 	}

--- a/printer/algebraic.go
+++ b/printer/algebraic.go
@@ -164,7 +164,7 @@ func algMove(gameStep core.GameStep, gameCharacteristics GameCharacteristics) st
 }
 
 func algResign(gameStep core.GameStep, gameCharacteristics GameCharacteristics) string {
-	if !gameStep.StepAction.IsResign || gameCharacteristics.usesEndGameSymbol == nil {
+	if (!gameStep.StepAction.IsResign && !gameStep.StepAction.IsDraw) || gameCharacteristics.usesEndGameSymbol == nil {
 		return ""
 	}
 	return fmt.Sprintf("%v", *gameCharacteristics.usesEndGameSymbol)
@@ -175,7 +175,7 @@ func (p AlgebraicPrinter) PrintAction(gameStep core.GameStep, gameCharacteristic
 	if gameStep.StepAction.IsCastle {
 		return algCastle(gameStep, gameCharacteristics), nil
 	}
-	if gameStep.StepAction.IsResign {
+	if gameStep.StepAction.IsResign || gameStep.StepAction.IsDraw {
 		return algResign(gameStep, gameCharacteristics), nil
 	}
 	if gameStep.StepAction.IsCapture {

--- a/printer/coordinate.go
+++ b/printer/coordinate.go
@@ -17,7 +17,7 @@ func (p CoordinatePrinter) PrintAction(gameStep core.GameStep, gameCharacteristi
 	if gameStep.StepAction.IsCastle {
 		return algCastle(gameStep, gameCharacteristics) + coordCheck(gameStep, gameCharacteristics), nil
 	}
-	if gameStep.StepAction.IsResign {
+	if gameStep.StepAction.IsResign || gameStep.StepAction.IsDraw {
 		return algResign(gameStep, gameCharacteristics), nil
 	}
 	delimiter := "-"

--- a/printer/descriptive.go
+++ b/printer/descriptive.go
@@ -120,7 +120,7 @@ func move(gameStep core.GameStep, gameCharacteristics GameCharacteristics) strin
 }
 
 func resign(gameStep core.GameStep, gameCharacteristics GameCharacteristics) string {
-	if !gameStep.StepAction.IsResign || gameCharacteristics.usesEndGameSymbol == nil {
+	if (!gameStep.StepAction.IsResign && !gameStep.StepAction.IsDraw) || gameCharacteristics.usesEndGameSymbol == nil {
 		return ""
 	}
 	return fmt.Sprintf("%v", *gameCharacteristics.usesEndGameSymbol)
@@ -132,7 +132,7 @@ func (p DescriptivePrinter) PrintAction(gameStep core.GameStep, gameCharacterist
 	if gameStep.StepAction.IsCastle {
 		return castle(gameStep, gameCharacteristics), nil
 	}
-	if gameStep.StepAction.IsResign {
+	if gameStep.StepAction.IsResign || gameStep.StepAction.IsDraw {
 		return resign(gameStep, gameCharacteristics), nil
 	}
 	if gameStep.StepAction.IsCapture {


### PR DESCRIPTION
Adds a draw-proposal terminal action alongside resign, available at any point, surfaced through InputAction/OutputAction; draw result markers in parsed notations now match it. Closes #12.