### PR TITLE
PGN completeness: RAV variations, bare NAGs, comments, printing, API exposure

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -114,30 +114,36 @@ func parseNotationAutoDetect(parsedGame core.Game, notationString string) ([]cor
 	notationString = strings.TrimSpace(notationString)
 	type notationCandidate struct {
 		name  string
-		parse func() ([]core.GameStep, error)
+		parse func() ([]core.GameStep, map[string]string, error)
+	}
+	noMetadata := func(parse func() ([]core.GameStep, error)) func() ([]core.GameStep, map[string]string, error) {
+		return func() ([]core.GameStep, map[string]string, error) {
+			gameSteps, err := parse()
+			return gameSteps, nil, err
+		}
 	}
 	candidates := []notationCandidate{
-		{"Algebraic Notation", func() ([]core.GameStep, error) {
+		{"Algebraic Notation", noMetadata(func() ([]core.GameStep, error) {
 			return parser.NewNotationParserAlgebraic(parser.Characteristics{}).Parse(parsedGame, notationString)
-		}},
-		{"ICCF Notation", func() ([]core.GameStep, error) {
+		})},
+		{"ICCF Notation", noMetadata(func() ([]core.GameStep, error) {
 			return parser.NewNotationParserICCF(parser.Characteristics{}).Parse(parsedGame, notationString)
-		}},
-		{"Smith Notation", func() ([]core.GameStep, error) {
+		})},
+		{"Smith Notation", noMetadata(func() ([]core.GameStep, error) {
 			return parser.NewNotationParserSmith(parser.Characteristics{}).Parse(parsedGame, notationString)
-		}},
-		{"Coordinate Notation", func() ([]core.GameStep, error) {
+		})},
+		{"Coordinate Notation", noMetadata(func() ([]core.GameStep, error) {
 			return parser.NewNotationParserCoordinate(parser.Characteristics{}).Parse(parsedGame, notationString)
-		}},
-		{"Descriptive Notation", func() ([]core.GameStep, error) {
+		})},
+		{"Descriptive Notation", noMetadata(func() ([]core.GameStep, error) {
 			return parser.NewNotationParserDescriptive(parser.Characteristics{}).Parse(parsedGame, notationString)
-		}},
-		{"PGN", func() ([]core.GameStep, error) {
+		})},
+		{"PGN", func() ([]core.GameStep, map[string]string, error) {
 			parsed, err := parser.NewGenericNotationParser(pgn.NewVariantPGN()).Parse(parsedGame, notationString)
 			if parsed == nil {
-				return nil, err
+				return nil, nil, err
 			}
-			return parsed.GameSteps, err
+			return parsed.GameSteps, parsed.Metadata, err
 		}},
 	}
 
@@ -146,12 +152,13 @@ func parseNotationAutoDetect(parsedGame core.Game, notationString string) ([]cor
 		bestResult *OutputParseResult
 	)
 	for _, candidate := range candidates {
-		gameSteps, err := candidate.parse()
+		gameSteps, metadata, err := candidate.parse()
 		validSteps := len(gameSteps)
 		result := OutputParseResult{
 			NotationName:       candidate.name,
 			ParseWasSuccessful: err == nil,
 			ValidActionCount:   validSteps,
+			Metadata:           metadata,
 		}
 		if err != nil {
 			result.Error = err.Error()
@@ -174,7 +181,7 @@ func parseNotationAutoDetect(parsedGame core.Game, notationString string) ([]cor
 // some notation, auto-detects the source notation, and re-renders every move in the
 // target notation.
 //
-// `targetNotation` must be one of: `{Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith}`
+// `targetNotation` must be one of: `{Algebraic|Figurine|Descriptive|Coordinate|ICCF|Smith|PGN}`
 // (case-insensitive).
 //
 // Partial input still converts the valid prefix: the result reports the detected
@@ -285,6 +292,8 @@ func notationPrinter(targetNotation string) (printer.NotationPrinter, printer.Ga
 		return printer.ICCFPrinter{}, printer.GameCharacteristics{}, nil
 	case "smith":
 		return printer.SmithPrinter{}, printer.GameCharacteristics{}, nil
+	case "pgn":
+		return printer.PGNPrinter{}, printer.SANCharacteristics(), nil
 	}
 	return nil, printer.GameCharacteristics{}, errUnknownTargetNotation
 }

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -190,11 +190,12 @@ type OutputAction struct {
 //
 // - `error` describes why the parse stopped, when `parseWasSuccessful` is false.
 type OutputParseResult struct {
-	NotationName       string           `json:"notationName"`
-	ParseWasSuccessful bool             `json:"parseWasSuccessful"`
-	ValidActionCount   int              `json:"validActionCount"`
-	Steps              []OutputGameStep `json:"steps"`
-	Error              string           `json:"error,omitempty"`
+	NotationName       string            `json:"notationName"`
+	ParseWasSuccessful bool              `json:"parseWasSuccessful"`
+	ValidActionCount   int               `json:"validActionCount"`
+	Steps              []OutputGameStep  `json:"steps"`
+	Metadata           map[string]string `json:"metadata,omitempty"` // e.g. PGN tag pairs
+	Error              string            `json:"error,omitempty"`
 }
 
 // OutputGameStep is the output interface that describes a step in a parsed

--- a/api/pgn_api_test.go
+++ b/api/pgn_api_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNotation_PGNMetadataExposed(t *testing.T) {
+	pgn := `[Event "API Test"]
+[White "Alice"]
+[Black "Bob"]
+
+1. e4 e5 2. Nf3 Nc6 1-0`
+	_, result, err := New().ParseNotation(InputGame{}, pgn)
+	require.NoError(t, err)
+	require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+	assert.Equal(t, "PGN", result.NotationName)
+	assert.Equal(t, "API Test", result.Metadata["Event"])
+	assert.Equal(t, "Alice", result.Metadata["White"])
+	assert.Equal(t, "Bob", result.Metadata["Black"])
+}
+
+func TestParseNotation_PGNWithVariationsAndNAGs(t *testing.T) {
+	pgn := `[Event "Annotated"]
+
+1. e4 $1 {King's pawn} e5 (1... c5 {Sicilian} 2. Nf3) 2. Nf3 Nc6 *`
+	_, result, err := New().ParseNotation(InputGame{}, pgn)
+	require.NoError(t, err)
+	require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+	assert.Equal(t, "PGN", result.NotationName)
+	assert.Equal(t, 5, result.ValidActionCount) // 4 moves + result marker
+}
+
+func TestConvertNotation_ToPGN(t *testing.T) {
+	_, result, err := New().ConvertNotation(InputGame{}, "1. e4 e5 2. Nf3 Nc6", "PGN")
+	require.NoError(t, err)
+	require.True(t, result.ParseWasSuccessful, "parse failed: %v", result.Error)
+	actionStrings := make([]string, 0, len(result.Steps))
+	for _, s := range result.Steps {
+		actionStrings = append(actionStrings, s.ActionString)
+	}
+	assert.Equal(t, []string{"e4", "e5", "Nf3", "Nc6"}, actionStrings)
+}
+
+func TestParseNotation_PGNPartialParse(t *testing.T) {
+	pgn := `1. e4 e5 2. Qxf7 Nc6`
+	_, result, err := New().ParseNotation(InputGame{}, pgn)
+	require.NoError(t, err)
+	assert.False(t, result.ParseWasSuccessful)
+	assert.Equal(t, 2, result.ValidActionCount, "the two valid moves before the failure should be counted")
+	assert.True(t, strings.Contains(result.Error, "Qxf7"), "error should name the failing move: %v", result.Error)
+}

--- a/core/entities.go
+++ b/core/entities.go
@@ -416,6 +416,7 @@ func (p Piece) String() string {
 
 type GameStep struct {
 	StepString      string
+	StepComment     string
 	StepAction      Action
 	StepGame        Game
 	StepPreMoveGame Game
@@ -424,6 +425,7 @@ type GameStep struct {
 func (s GameStep) Clone() GameStep {
 	return GameStep{
 		StepString:      s.StepString,
+		StepComment:     s.StepComment,
 		StepAction:      s.StepAction,
 		StepGame:        s.StepGame.Clone(),
 		StepPreMoveGame: s.StepPreMoveGame.Clone(),

--- a/parser/generic_notation_parser.go
+++ b/parser/generic_notation_parser.go
@@ -21,6 +21,9 @@ const (
 type Token struct {
 	Value string
 	Type  TokenType
+	// Comment holds the text of any comment(s) attached to this token (e.g. PGN
+	// {...} or ; comments following a move), without delimiters.
+	Comment string
 }
 
 // ParserVariant defines the interface for notation-specific parsing logic.
@@ -97,11 +100,13 @@ func (p *GenericNotationParser) Parse(initialGame core.Game, s string) (*ParsedG
 	}
 
 	// Step 2: Loop through parseHalfMoves
-	// The variant pops tokens, and we handle game state management
+	// The variant pops tokens, and we handle game state management.
+	// On a mid-game failure, parsing stops but the valid prefix of steps is
+	// returned along with the error, matching the other parsers' behavior.
 	for {
 		token, hasMore, err := p.variant.PopHalfMove(parsingGame)
 		if err != nil {
-			return nil, err
+			return parsingGame.Build(), err
 		}
 		if token == nil {
 			break
@@ -109,7 +114,7 @@ func (p *GenericNotationParser) Parse(initialGame core.Game, s string) (*ParsedG
 
 		// Process the token based on its type
 		if err := p.ProcessToken(parsingGame, token); err != nil {
-			return nil, err
+			return parsingGame.Build(), err
 		}
 
 		if !hasMore {
@@ -195,6 +200,7 @@ func (p *GenericNotationParser) ProcessToken(pg *ParsingGame, token *Token) erro
 				newAlternative := alt.Clone()
 				newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{
 					StepString:      token.Value,
+					StepComment:     token.Comment,
 					StepAction:      action,
 					StepGame:        newGame,
 					StepPreMoveGame: currentGame,
@@ -218,6 +224,7 @@ func (p *GenericNotationParser) ProcessToken(pg *ParsingGame, token *Token) erro
 			newAlternative := alt.Clone()
 			newAlternative.GameSteps = append(newAlternative.GameSteps, core.GameStep{
 				StepString:      token.Value,
+				StepComment:     token.Comment,
 				StepAction:      core.Action{},     // Empty action for result markers
 				StepGame:        alt.CurrentGame(), // Game state doesn't change
 				StepPreMoveGame: alt.CurrentGame(),

--- a/parser/pgn/pgn_completeness_test.go
+++ b/parser/pgn/pgn_completeness_test.go
@@ -1,0 +1,114 @@
+package pgn
+
+import (
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/marianogappa/cheesse/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parsePGN(t *testing.T, pgn string) (*parser.ParsedGame, error) {
+	t.Helper()
+	initialGame, err := core.NewGameFromFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+	require.NoError(t, err)
+	return parser.NewGenericNotationParser(NewVariantPGN()).Parse(initialGame, pgn)
+}
+
+func TestPGNRAVVariations(t *testing.T) {
+	t.Run("skips a simple variation", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 e5 (1... c5 2. Nf3) 2. Nf3 Nc6")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 4)
+		assert.Equal(t, "e4", parsed.GameSteps[0].StepString)
+		assert.Equal(t, "e5", parsed.GameSteps[1].StepString)
+		assert.Equal(t, "Nf3", parsed.GameSteps[2].StepString)
+		assert.Equal(t, "Nc6", parsed.GameSteps[3].StepString)
+	})
+
+	t.Run("skips nested variations", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 e5 (1... c5 (1... e6 2. d4) 2. Nf3) 2. Nf3")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+		assert.Equal(t, "Nf3", parsed.GameSteps[2].StepString)
+	})
+
+	t.Run("skips variation containing comments with parens", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 e5 (1... c5 {sicilian (sharp)} 2. Nf3) 2. Nf3")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+	})
+
+	t.Run("variation before first move of a game continuation", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 (1. d4 d5) 1... e5 2. Nf3")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+		assert.Equal(t, "e5", parsed.GameSteps[1].StepString)
+	})
+}
+
+func TestPGNBareNAGs(t *testing.T) {
+	t.Run("bare NAG after move", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 $1 e5 $14 2. Nf3")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+		assert.Equal(t, "e4", parsed.GameSteps[0].StepString)
+		assert.Equal(t, "e5", parsed.GameSteps[1].StepString)
+	})
+
+	t.Run("parenthesized NAG still works", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 ($1) e5")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 2)
+	})
+}
+
+func TestPGNCommentsAttached(t *testing.T) {
+	t.Run("curly comment attaches to preceding move", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 {best by test} e5 2. Nf3 {develops}")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+		assert.Equal(t, "best by test", parsed.GameSteps[0].StepComment)
+		assert.Equal(t, "", parsed.GameSteps[1].StepComment)
+		assert.Equal(t, "develops", parsed.GameSteps[2].StepComment)
+	})
+
+	t.Run("semicolon comment attaches to preceding move", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 e5 ; the open game\n2. Nf3")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 3)
+		assert.Equal(t, "the open game", parsed.GameSteps[1].StepComment)
+	})
+
+	t.Run("multiple comments concatenate", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 {one} {two} e5")
+		require.NoError(t, err)
+		require.Len(t, parsed.GameSteps, 2)
+		assert.Equal(t, "one two", parsed.GameSteps[0].StepComment)
+	})
+}
+
+func TestPGNPartialParse(t *testing.T) {
+	t.Run("invalid move mid-game returns valid prefix and error", func(t *testing.T) {
+		parsed, err := parsePGN(t, "1. e4 e5 2. Qxf7 Nc6")
+		require.Error(t, err)
+		require.NotNil(t, parsed)
+		assert.Len(t, parsed.GameSteps, 2, "the two valid moves before the failure should be returned")
+	})
+}
+
+func TestPGNRealWorldAnnotatedGame(t *testing.T) {
+	pgn := `[Event "Annotated"]
+[White "A"]
+[Black "B"]
+
+1. e4 $1 {King's pawn} e5 (1... c5 {Sicilian} 2. Nf3 (2. c3 $6) 2... d6) 2. Nf3 {attacks e5} Nc6 3. Bb5 $14 a6 1/2-1/2`
+	parsed, err := parsePGN(t, pgn)
+	require.NoError(t, err)
+	require.Len(t, parsed.GameSteps, 7) // 6 moves + result marker
+	assert.Equal(t, "King's pawn", parsed.GameSteps[0].StepComment)
+	assert.Equal(t, "attacks e5", parsed.GameSteps[2].StepComment)
+	assert.Equal(t, "1/2-1/2", parsed.GameSteps[6].StepString)
+	assert.Equal(t, "Annotated", parsed.Metadata["Event"])
+}

--- a/parser/pgn/variant.go
+++ b/parser/pgn/variant.go
@@ -42,7 +42,8 @@ func (p *VariantPGN) Initialize(initialGame core.Game, s string) (*parser.Parsin
 // It handles all token peeking and position management internally.
 // Only the token extraction logic is PGN-specific; game state management is handled generically.
 func (p *VariantPGN) PopHalfMove(pg *parser.ParsingGame) (*parser.Token, bool, error) {
-	// First, skip any move numbers
+	// First, skip any move numbers, comments, annotations and variations that
+	// precede the next half move.
 	for {
 		tokenValue, tokenType, newPos, err := peekToken(pg.Remaining, pg.Pos)
 		if err != nil {
@@ -54,8 +55,9 @@ func (p *VariantPGN) PopHalfMove(pg *parser.ParsingGame) (*parser.Token, bool, e
 			return nil, false, nil
 		}
 
-		if tokenType == tokenTypeMoveNumber {
-			// Skip move numbers, but check if position actually advanced
+		if tokenType == tokenTypeMoveNumber || tokenType == tokenTypeRAV ||
+			tokenType == tokenTypeAnnotation || tokenType == tokenTypeComment || tokenType == tokenTypeCurlyComment {
+			// Skip, but check if position actually advanced
 			if newPos <= pg.Pos {
 				// Position didn't advance, break to avoid infinite loop
 				break
@@ -96,7 +98,7 @@ func (p *VariantPGN) PopHalfMove(pg *parser.ParsingGame) (*parser.Token, bool, e
 		Type:  genericType,
 	}
 
-	// Now process any comments or annotations that follow the half move
+	// Now process any comments, annotations or variations that follow the half move
 	for {
 		nextTokenValue, nextType, nextPos, err := peekToken(pg.Remaining, pg.Pos)
 		if err != nil {
@@ -108,20 +110,25 @@ func (p *VariantPGN) PopHalfMove(pg *parser.ParsingGame) (*parser.Token, bool, e
 			return token, false, nil
 		}
 
-		// If it's a comment or annotation, consume it
-		if nextType == tokenTypeAnnotation || nextType == tokenTypeComment || nextType == tokenTypeCurlyComment {
-			// Consume the comment/annotation (for now, just skip it)
-			// In a later version, they will be added to the action
+		// If it's a comment, attach its text to the token and consume it
+		if nextType == tokenTypeComment || nextType == tokenTypeCurlyComment {
 			// Check if position actually advanced to avoid infinite loop
 			if nextPos <= pg.Pos {
 				return token, false, nil
+			}
+			commentText := commentText(nextTokenValue, nextType)
+			if commentText != "" {
+				if token.Comment != "" {
+					token.Comment += " "
+				}
+				token.Comment += commentText
 			}
 			pg.Pos = nextPos
 			continue
 		}
 
-		// If it's a move number, skip it
-		if nextType == tokenTypeMoveNumber {
+		// If it's an annotation, move number or variation, skip it
+		if nextType == tokenTypeAnnotation || nextType == tokenTypeMoveNumber || nextType == tokenTypeRAV {
 			// Check if position actually advanced to avoid infinite loop
 			if nextPos <= pg.Pos {
 				return token, false, nil
@@ -139,6 +146,18 @@ func (p *VariantPGN) PopHalfMove(pg *parser.ParsingGame) (*parser.Token, bool, e
 		// Otherwise, we're done (no more half moves)
 		return token, false, nil
 	}
+}
+
+// commentText strips the delimiters from a comment token: braces for {...}
+// comments, the leading semicolon and trailing newline for ; comments.
+func commentText(tokenValue string, t tokenType) string {
+	switch t {
+	case tokenTypeCurlyComment:
+		return strings.TrimSpace(strings.Trim(tokenValue, "{}"))
+	case tokenTypeComment:
+		return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(tokenValue), ";"))
+	}
+	return ""
 }
 
 // Finalize implements ParserVariant.Finalize for PGN.
@@ -314,7 +333,7 @@ func peekToken(pgn string, pos int) (string, tokenType, int, error) {
 		pos = startPos
 	}
 
-	// Check for annotations: ($1), ($2), etc.
+	// Check for annotations: ($1), ($2), etc. (nonstandard parenthesized NAGs)
 	if char == '(' && pos+1 < len(pgn) && pgn[pos+1] == '$' {
 		pos += 2 // Skip "($"
 		for pos < len(pgn) && pgn[pos] >= '0' && pgn[pos] <= '9' {
@@ -324,6 +343,43 @@ func peekToken(pgn string, pos int) (string, tokenType, int, error) {
 			pos++
 			return pgn[startPos:pos], tokenTypeAnnotation, pos, nil
 		}
+		pos = startPos
+	}
+
+	// Check for RAV variations: ( ... ) with correct nesting. Comments inside a
+	// variation may contain unbalanced parentheses, so track them.
+	if char == '(' {
+		pos++
+		depth := 1
+		inComment := false
+		for pos < len(pgn) && depth > 0 {
+			switch {
+			case inComment:
+				if pgn[pos] == '}' {
+					inComment = false
+				}
+			case pgn[pos] == '{':
+				inComment = true
+			case pgn[pos] == '(':
+				depth++
+			case pgn[pos] == ')':
+				depth--
+			}
+			pos++
+		}
+		return pgn[startPos:pos], tokenTypeRAV, pos, nil
+	}
+
+	// Check for bare NAGs: $1, $14, etc. (standard PGN)
+	if char == '$' {
+		pos++
+		for pos < len(pgn) && pgn[pos] >= '0' && pgn[pos] <= '9' {
+			pos++
+		}
+		if pos > startPos+1 {
+			return pgn[startPos:pos], tokenTypeAnnotation, pos, nil
+		}
+		pos = startPos
 	}
 
 	// Check for curly comments: {comment}
@@ -421,4 +477,5 @@ const (
 	tokenTypeCurlyComment
 	tokenTypeMoveNumber
 	tokenTypeResult
+	tokenTypeRAV
 )

--- a/printer/pgn.go
+++ b/printer/pgn.go
@@ -1,0 +1,153 @@
+package printer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/marianogappa/cheesse/core"
+)
+
+// PGNPrinter renders a game as a PGN document: a tag-pair section (the Seven Tag
+// Roster plus any extra metadata) followed by the movetext with move numbers,
+// comments, the result marker, and lines wrapped at 80 columns.
+type PGNPrinter struct {
+	// Metadata holds tag pairs to render in the tag section (e.g. from a parsed
+	// PGN's headers). Seven Tag Roster keys missing from it get "?" placeholders.
+	Metadata map[string]string
+}
+
+var pgnSevenTagRoster = []string{"Event", "Site", "Date", "Round", "White", "Black", "Result"}
+
+// PrintGame renders the full PGN document as lines: the tag section, a blank
+// line, then the movetext wrapped at 80 columns.
+func (p PGNPrinter) PrintGame(gameSteps []core.GameStep, gameCharacteristics GameCharacteristics) ([]string, error) {
+	result := p.resultMarker(gameSteps)
+
+	lines := []string{}
+	for _, tag := range pgnSevenTagRoster {
+		value, ok := p.Metadata[tag]
+		if !ok {
+			switch tag {
+			case "Date":
+				value = "????.??.??"
+			case "Result":
+				value = result
+			default:
+				value = "?"
+			}
+		}
+		lines = append(lines, fmt.Sprintf("[%s %q]", tag, value))
+	}
+	// Passthrough of any non-STR metadata, in deterministic order.
+	extraKeys := []string{}
+	for k := range p.Metadata {
+		isSTR := false
+		for _, tag := range pgnSevenTagRoster {
+			if k == tag {
+				isSTR = true
+				break
+			}
+		}
+		if !isSTR {
+			extraKeys = append(extraKeys, k)
+		}
+	}
+	sort.Strings(extraKeys)
+	for _, k := range extraKeys {
+		lines = append(lines, fmt.Sprintf("[%s %q]", k, p.Metadata[k]))
+	}
+	lines = append(lines, "")
+
+	movetext, err := p.movetext(gameSteps, result)
+	if err != nil {
+		return nil, err
+	}
+	lines = append(lines, wrapText(movetext, 80)...)
+	return lines, nil
+}
+
+// PrintAction renders a single action in SAN (the movetext language of PGN).
+func (p PGNPrinter) PrintAction(gameStep core.GameStep, gameCharacteristics GameCharacteristics) (string, error) {
+	return AlgebraicPrinter{}.PrintAction(gameStep, gameCharacteristics)
+}
+
+// resultMarker derives the game's result marker from the final step: an explicit
+// result-marker step wins; otherwise the final game state decides.
+func (p PGNPrinter) resultMarker(gameSteps []core.GameStep) string {
+	if len(gameSteps) == 0 {
+		return "*"
+	}
+	last := gameSteps[len(gameSteps)-1]
+	switch last.StepString {
+	case "1-0", "0-1", "1/2-1/2", "*":
+		return last.StepString
+	}
+	finalGame := last.StepGame
+	switch {
+	case finalGame.IsCheckmate && finalGame.GameOverWinner.String() == "White",
+		last.StepAction.IsResign && last.StepAction.FromPiece.Owner.String() == "Black":
+		return "1-0"
+	case finalGame.IsCheckmate && finalGame.GameOverWinner.String() == "Black",
+		last.StepAction.IsResign && last.StepAction.FromPiece.Owner.String() == "White":
+		return "0-1"
+	case finalGame.IsDraw, finalGame.IsStalemate, last.StepAction.IsDraw:
+		return "1/2-1/2"
+	}
+	return "*"
+}
+
+func (p PGNPrinter) movetext(gameSteps []core.GameStep, result string) (string, error) {
+	sanCharacteristics := SANCharacteristics()
+	var sb strings.Builder
+	needsMoveNumber := true
+	for _, gameStep := range gameSteps {
+		// Result markers and terminal actions are rendered via the result marker at the end.
+		if gameStep.StepAction == (core.Action{}) || gameStep.StepAction.IsResign || gameStep.StepAction.IsDraw {
+			continue
+		}
+		san, err := AlgebraicPrinter{}.PrintAction(gameStep, sanCharacteristics)
+		if err != nil {
+			return "", err
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		preMoveGame := gameStep.StepPreMoveGame
+		if preMoveGame.Turn() == core.ColorWhite {
+			fmt.Fprintf(&sb, "%d. ", preMoveGame.FullMoveNumber)
+		} else if needsMoveNumber {
+			fmt.Fprintf(&sb, "%d... ", preMoveGame.FullMoveNumber)
+		}
+		sb.WriteString(san)
+		needsMoveNumber = false
+		if gameStep.StepComment != "" {
+			fmt.Fprintf(&sb, " {%s}", gameStep.StepComment)
+			needsMoveNumber = true // Conventionally re-state the move number after a comment
+		}
+	}
+	if sb.Len() > 0 {
+		sb.WriteByte(' ')
+	}
+	sb.WriteString(result)
+	return sb.String(), nil
+}
+
+// wrapText greedily wraps the text at the given column, breaking on spaces.
+func wrapText(text string, width int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{""}
+	}
+	lines := []string{}
+	current := words[0]
+	for _, word := range words[1:] {
+		if len(current)+1+len(word) > width {
+			lines = append(lines, current)
+			current = word
+			continue
+		}
+		current += " " + word
+	}
+	return append(lines, current)
+}

--- a/printer/pgn_test.go
+++ b/printer/pgn_test.go
@@ -1,0 +1,97 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/marianogappa/cheesse/core"
+	"github.com/marianogappa/cheesse/parser"
+	"github.com/marianogappa/cheesse/parser/pgn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parsePGNForPrinting(t *testing.T, s string) *parser.ParsedGame {
+	t.Helper()
+	initialGame, err := core.NewGameFromFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+	require.NoError(t, err)
+	parsed, err := parser.NewGenericNotationParser(pgn.NewVariantPGN()).Parse(initialGame, s)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestPGNPrinterTagSection(t *testing.T) {
+	parsed := parsePGNForPrinting(t, `[Event "Casual"]
+[White "Alice"]
+[Black "Bob"]
+[ECO "C50"]
+
+1. e4 e5 1/2-1/2`)
+
+	p := PGNPrinter{Metadata: parsed.Metadata}
+	lines, err := p.PrintGame(parsed.GameSteps, SANCharacteristics())
+	require.NoError(t, err)
+	doc := strings.Join(lines, "\n")
+
+	assert.Contains(t, doc, `[Event "Casual"]`)
+	assert.Contains(t, doc, `[White "Alice"]`)
+	assert.Contains(t, doc, `[Black "Bob"]`)
+	assert.Contains(t, doc, `[ECO "C50"]`, "non-STR metadata should pass through")
+	assert.Contains(t, doc, `[Site "?"]`, "missing STR tags get placeholders")
+	assert.Contains(t, doc, `[Date "????.??.??"]`)
+	assert.Contains(t, doc, "1. e4 e5 1/2-1/2")
+}
+
+func TestPGNPrinterMovetext(t *testing.T) {
+	t.Run("move numbers and result", func(t *testing.T) {
+		parsed := parsePGNForPrinting(t, "1. e4 e5 2. Nf3 Nc6 1-0")
+		lines, err := PGNPrinter{}.PrintGame(parsed.GameSteps, SANCharacteristics())
+		require.NoError(t, err)
+		doc := strings.Join(lines, "\n")
+		assert.Contains(t, doc, "1. e4 e5 2. Nf3 Nc6 1-0")
+	})
+
+	t.Run("comments are preserved", func(t *testing.T) {
+		parsed := parsePGNForPrinting(t, "1. e4 {King's pawn} e5 2. Nf3")
+		lines, err := PGNPrinter{}.PrintGame(parsed.GameSteps, SANCharacteristics())
+		require.NoError(t, err)
+		doc := strings.Join(lines, "\n")
+		assert.Contains(t, doc, "1. e4 {King's pawn} 1... e5 2. Nf3")
+	})
+
+	t.Run("no explicit result yields *", func(t *testing.T) {
+		parsed := parsePGNForPrinting(t, "1. e4 e5")
+		lines, err := PGNPrinter{}.PrintGame(parsed.GameSteps, SANCharacteristics())
+		require.NoError(t, err)
+		doc := strings.Join(lines, "\n")
+		assert.Contains(t, doc, "1. e4 e5 *")
+		assert.Contains(t, doc, `[Result "*"]`)
+	})
+
+	t.Run("long games wrap at 80 columns", func(t *testing.T) {
+		parsed := parsePGNForPrinting(t, "1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7")
+		lines, err := PGNPrinter{}.PrintGame(parsed.GameSteps, SANCharacteristics())
+		require.NoError(t, err)
+		for _, line := range lines {
+			assert.LessOrEqual(t, len(line), 80, "line exceeds 80 columns: %q", line)
+		}
+	})
+}
+
+func TestPGNPrinterRoundTrip(t *testing.T) {
+	original := `[Event "RT"]
+[White "A"]
+[Black "B"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 1-0`
+	parsed := parsePGNForPrinting(t, original)
+	lines, err := PGNPrinter{Metadata: parsed.Metadata}.PrintGame(parsed.GameSteps, SANCharacteristics())
+	require.NoError(t, err)
+
+	reparsed := parsePGNForPrinting(t, strings.Join(lines, "\n"))
+	require.Equal(t, len(parsed.GameSteps), len(reparsed.GameSteps))
+	for i := range parsed.GameSteps {
+		assert.Equal(t, parsed.GameSteps[i].StepAction, reparsed.GameSteps[i].StepAction, "step %d differs", i)
+	}
+	assert.Equal(t, "RT", reparsed.Metadata["Event"])
+}


### PR DESCRIPTION
Completes the PGN pipeline: parses RAV variations and bare NAGs, preserves comments on steps, returns partial parses on mid-game errors, adds a PGN printer (tags + movetext + wrapping), and exposes PGN as a conversion target and its metadata through the API. Closes #27.