### PR TITLE
InputAction should support inputting actions by using any notation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,7 @@ var (
 	errInvalidPieceTypeName                = errors.New("invalid piece type name: please use one of {Queen|King|Bishop|Knight|Rook|Pawn} or empty string")
 	errInvalidActionForGivenGame           = errors.New("the specified action is invalid for the specified game")
 	errInvalidPositionHistory              = errors.New("invalid position history: entries must be hex-encoded position hashes from a previous response")
+	errAmbiguousActionString               = errors.New("the specified action string is ambiguous: more than one action matches it; please disambiguate")
 )
 
 // DefaultGame returns the initial game of chess, with all pieces on their default positions

--- a/api/api_entities.go
+++ b/api/api_entities.go
@@ -29,9 +29,9 @@ type InputGame struct {
 
 // InputAction is the input interface to supply a chess action.
 //
-// - `fromSquare` and `toSquare` are required (unless `isResign` or `isDraw` is set),
-// and must be board cells described in Algebraic Notation (e.g. `e2`). Note that
-// `a1` is where the White Queen's Rook starts.
+// - `fromSquare` and `toSquare` are required (unless `isResign`, `isDraw` or
+// `actionString` is set), and must be board cells described in Algebraic Notation
+// (e.g. `e2`). Note that `a1` is where the White Queen's Rook starts.
 //
 // - `promotionPieceType` is only required if the action is a promotion.
 //
@@ -39,12 +39,17 @@ type InputGame struct {
 //
 // - `isResign` resigns the game for the player to move; `isDraw` proposes a draw,
 // which the engine assumes accepted. When either is set, the other fields are ignored.
+//
+// - `actionString` supplies the action as a single move in any supported notation
+// (e.g. `Nf3`, `♘f3`, `g1f3`, `N-KB3`, `7163`); the notation is auto-detected. When
+// set, `fromSquare`/`toSquare`/`promotionPieceType` are ignored.
 type InputAction struct {
 	FromSquare         string `json:"fromSquare"`
 	ToSquare           string `json:"toSquare"`
 	PromotionPieceType string `json:"promotionPieceType"`
 	IsResign           bool   `json:"isResign"`
 	IsDraw             bool   `json:"isDraw"`
+	ActionString       string `json:"actionString"`
 }
 
 // Board is one of the input interfaces to supply a chess game.

--- a/api/api_utils.go
+++ b/api/api_utils.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/marianogappa/cheesse/core"
+	"github.com/marianogappa/cheesse/parser"
+	"github.com/marianogappa/cheesse/parser/pgn"
 )
 
 func (a API) parseGame(g InputGame) (core.Game, error) {
@@ -47,7 +49,24 @@ func (a API) parseAction(ia InputAction, g core.Game) (core.Action, error) {
 		return core.Action{}, errInvalidActionForGivenGame
 	}
 
-	// TODO eventually accept other forms of action input
+	// An action supplied as a move string in any notation: auto-detect and parse
+	// it as a one-move match. Some parsers (e.g. ICCF) require a move-number
+	// prefix, so retry with one if the bare string doesn't parse.
+	if ia.ActionString != "" {
+		// An ambiguous SAN string (e.g. "Nd2" with two knights reaching d2) must be
+		// rejected rather than silently resolved to an arbitrary action.
+		if matches, err := parser.NewGenericNotationParser(pgn.NewVariantPGN()).MatchHalfMove(ia.ActionString, g); err == nil && len(matches) > 1 {
+			return core.Action{}, errAmbiguousActionString
+		}
+		for _, s := range []string{ia.ActionString, "1. " + ia.ActionString} {
+			gameSteps, result := parseNotationAutoDetect(g, s)
+			if result.ParseWasSuccessful && len(gameSteps) == 1 {
+				return gameSteps[0].StepAction, nil
+			}
+		}
+		return core.Action{}, errInvalidActionForGivenGame
+	}
+
 	fromXY, err := a.algebraicToXY(strings.ToLower(ia.FromSquare))
 	if err != nil {
 		return core.Action{}, err

--- a/api/input_action_notation_test.go
+++ b/api/input_action_notation_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoActionWithActionString(t *testing.T) {
+	testCases := []struct {
+		name         string
+		actionString string
+		fromSquare   string
+		toSquare     string
+	}{
+		{"algebraic piece move", "Nf3", "g1", "f3"},
+		{"algebraic pawn move", "e4", "e2", "e4"},
+		{"figurine", "♘f3", "g1", "f3"},
+		{"coordinate", "g1-f3", "g1", "f3"},
+		{"smith", "g1f3", "g1", "f3"},
+		{"descriptive", "N-KB3", "g1", "f3"},
+		{"ICCF", "7163", "g1", "f3"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputGame, outputAction, err := New().DoAction(InputGame{}, InputAction{ActionString: tc.actionString})
+			require.NoError(t, err)
+			assert.Equal(t, tc.fromSquare, outputAction.FromPieceSquare)
+			assert.Equal(t, tc.toSquare, outputAction.ToSquare)
+			assert.Equal(t, "Black", outputGame.Board.Turn)
+		})
+	}
+}
+
+func TestDoActionWithActionStringPromotion(t *testing.T) {
+	outputGame, outputAction, err := New().DoAction(
+		InputGame{FENString: "8/5P1k/8/8/8/8/8/K7 w - - 0 1"},
+		InputAction{ActionString: "f8=N"},
+	)
+	require.NoError(t, err)
+	assert.True(t, outputAction.IsPromotion)
+	assert.Equal(t, "Knight", outputAction.PromotionPieceType)
+	assert.Equal(t, "Knight", outputGame.WhitePieces["f8"])
+}
+
+func TestDoActionWithActionStringCastle(t *testing.T) {
+	_, outputAction, err := New().DoAction(
+		InputGame{FENString: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQK2R w KQkq - 0 1"},
+		InputAction{ActionString: "O-O"},
+	)
+	require.NoError(t, err)
+	assert.True(t, outputAction.IsKingsideCastle)
+}
+
+func TestDoActionWithActionStringErrors(t *testing.T) {
+	t.Run("illegal move", func(t *testing.T) {
+		_, _, err := New().DoAction(InputGame{}, InputAction{ActionString: "Qh5"})
+		assert.Equal(t, errInvalidActionForGivenGame, err)
+	})
+	t.Run("garbage input", func(t *testing.T) {
+		_, _, err := New().DoAction(InputGame{}, InputAction{ActionString: "xyzzy"})
+		assert.Equal(t, errInvalidActionForGivenGame, err)
+	})
+	t.Run("multiple moves are rejected", func(t *testing.T) {
+		_, _, err := New().DoAction(InputGame{}, InputAction{ActionString: "1. e4 e5"})
+		assert.Equal(t, errInvalidActionForGivenGame, err)
+	})
+	t.Run("ambiguous move is rejected", func(t *testing.T) {
+		// Two knights can reach d2: Nbd2 or Nfd2 required.
+		_, _, err := New().DoAction(
+			InputGame{FENString: "4k3/8/8/8/8/5N2/8/RN2K3 w - - 0 1"},
+			InputAction{ActionString: "Nd2"},
+		)
+		assert.Error(t, err)
+	})
+}
+
+func TestDoActionWithActionStringTakesPrecedenceOverSquares(t *testing.T) {
+	// When both actionString and squares are supplied, actionString wins.
+	_, outputAction, err := New().DoAction(InputGame{}, InputAction{
+		ActionString: "d4",
+		FromSquare:   "e2",
+		ToSquare:     "e4",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "d2", outputAction.FromPieceSquare)
+	assert.Equal(t, "d4", outputAction.ToSquare)
+}


### PR DESCRIPTION
Adds InputAction.actionString: a single move in any supported notation, auto-detected; ambiguous strings are rejected. Closes #11.